### PR TITLE
Array control detail customization

### DIFF
--- a/src/core/context/context.ts
+++ b/src/core/context/context.ts
@@ -10,13 +10,13 @@ import React, { useContext } from 'react';
 import { SchemaService } from '../api/schemaService';
 import { SchemaElement } from '../model';
 import { EditorAction } from '../model/actions';
-import { LinkedUISchemaElement } from '../model/uischema';
+import { EditorUISchemaElement } from '../model/uischema';
 import { SelectedElement } from '../selection';
 
 export interface EditorContext {
   schemaService: SchemaService;
   schema: SchemaElement | undefined;
-  uiSchema: LinkedUISchemaElement | undefined;
+  uiSchema: EditorUISchemaElement | undefined;
   dispatch: (action: EditorAction) => void;
   selection: SelectedElement;
   setSelection: (selection: SelectedElement) => void;
@@ -42,7 +42,7 @@ export const useSchema = (): SchemaElement | undefined => {
   return schema;
 };
 
-export const useUiSchema = (): LinkedUISchemaElement | undefined => {
+export const useUiSchema = (): EditorUISchemaElement | undefined => {
   const { uiSchema } = useEditorContext();
   return uiSchema;
 };

--- a/src/core/dnd/types.ts
+++ b/src/core/dnd/types.ts
@@ -9,9 +9,9 @@
 import { getArrayContainer, SchemaElement } from '../model';
 import {
   containsControls,
+  EditorLayout,
+  EditorUISchemaElement,
   getDetailContainer,
-  LinkedLayout,
-  LinkedUISchemaElement,
 } from '../model/uischema';
 import { getHierarchy } from '../util/tree';
 
@@ -23,12 +23,12 @@ export type DndType = NewUISchemaElement | MoveUISchemaElement;
 
 export interface NewUISchemaElement {
   type: 'newUiSchemaElement';
-  uiSchemaElement: LinkedUISchemaElement;
+  uiSchemaElement: EditorUISchemaElement;
   schema?: SchemaElement;
 }
 
 const newUISchemaElement = (
-  uiSchemaElement: LinkedUISchemaElement,
+  uiSchemaElement: EditorUISchemaElement,
   schema?: SchemaElement
 ) => ({
   type: NEW_UI_SCHEMA_ELEMENT,
@@ -38,12 +38,12 @@ const newUISchemaElement = (
 
 export interface MoveUISchemaElement {
   type: 'moveUiSchemaElement';
-  uiSchemaElement: LinkedUISchemaElement;
+  uiSchemaElement: EditorUISchemaElement;
   schema?: SchemaElement;
 }
 
 const moveUISchemaElement = (
-  uiSchemaElement: LinkedUISchemaElement,
+  uiSchemaElement: EditorUISchemaElement,
   schema?: SchemaElement
 ) => ({
   type: MOVE_UI_SCHEMA_ELEMENT,
@@ -55,7 +55,7 @@ export const DndItems = { newUISchemaElement, moveUISchemaElement };
 
 export const canDropIntoLayout = (
   item: NewUISchemaElement,
-  layout: LinkedUISchemaElement
+  layout: EditorUISchemaElement
 ) => {
   // check scope changes
   const detailContainer = getDetailContainer(layout);
@@ -77,7 +77,7 @@ export const canDropIntoLayout = (
  */
 export const canDropIntoScope = (
   item: NewUISchemaElement,
-  scopeUISchemaElement: LinkedUISchemaElement | undefined
+  scopeUISchemaElement: EditorUISchemaElement | undefined
 ) => {
   // it's a control when there is a schema
   if (item.schema) {
@@ -102,10 +102,10 @@ export const canDropIntoScope = (
 
 export const canMoveSchemaElementTo = (
   item: MoveUISchemaElement,
-  layout: LinkedUISchemaElement,
+  layout: EditorUISchemaElement,
   index: number
 ) => {
-  const uiElementToMove = item.uiSchemaElement as LinkedUISchemaElement;
+  const uiElementToMove = item.uiSchemaElement as EditorUISchemaElement;
   // can't move the root element
   if (!uiElementToMove.parent) {
     return false;
@@ -116,7 +116,7 @@ export const canMoveSchemaElementTo = (
   }
   // can't move element next to itself (which would result in no change)
   if (layout === uiElementToMove.parent) {
-    const currentIndex = (uiElementToMove.parent as LinkedLayout).elements.indexOf(
+    const currentIndex = (uiElementToMove.parent as EditorLayout).elements.indexOf(
       uiElementToMove
     );
     if (currentIndex === index || currentIndex === index - 1) {

--- a/src/core/dnd/types.ts
+++ b/src/core/dnd/types.ts
@@ -6,8 +6,14 @@
  * ---------------------------------------------------------------------
  */
 
-import { SchemaElement } from '../model';
-import { LinkedUISchemaElement } from '../model/uischema';
+import { getArrayContainer, SchemaElement } from '../model';
+import {
+  containsControls,
+  getDetailContainer,
+  LinkedLayout,
+  LinkedUISchemaElement,
+} from '../model/uischema';
+import { getHierarchy } from '../util/tree';
 
 export const NEW_UI_SCHEMA_ELEMENT: 'newUiSchemaElement' = 'newUiSchemaElement';
 export const MOVE_UI_SCHEMA_ELEMENT: 'moveUiSchemaElement' =
@@ -17,13 +23,13 @@ export type DndType = NewUISchemaElement | MoveUISchemaElement;
 
 export interface NewUISchemaElement {
   type: 'newUiSchemaElement';
-  element: LinkedUISchemaElement;
-  schema?: any;
+  uiSchemaElement: LinkedUISchemaElement;
+  schema?: SchemaElement;
 }
 
 const newUISchemaElement = (
   uiSchemaElement: LinkedUISchemaElement,
-  schema?: any
+  schema?: SchemaElement
 ) => ({
   type: NEW_UI_SCHEMA_ELEMENT,
   uiSchemaElement,
@@ -32,7 +38,8 @@ const newUISchemaElement = (
 
 export interface MoveUISchemaElement {
   type: 'moveUiSchemaElement';
-  element: LinkedUISchemaElement;
+  uiSchemaElement: LinkedUISchemaElement;
+  schema?: SchemaElement;
 }
 
 const moveUISchemaElement = (
@@ -45,3 +52,83 @@ const moveUISchemaElement = (
 });
 
 export const DndItems = { newUISchemaElement, moveUISchemaElement };
+
+export const canDropIntoLayout = (
+  item: NewUISchemaElement,
+  layout: LinkedUISchemaElement
+) => {
+  // check scope changes
+  const detailContainer = getDetailContainer(layout);
+  if (!canDropIntoScope(item, detailContainer)) {
+    return false;
+  }
+  // check whether
+  return true;
+};
+
+/**
+ * Check whether the element to drop fits into the given scope,
+ * e.g. whether a nested array object is dropped into the correct array ui schema control.
+ *
+ * @param item the drag and drop item
+ * @param scopeChangingElement the nearest scope changing element,
+ * e.g. the nearest array control into which shall be dropped.
+ * Use `undefined` when dropping outside of any scope changing element.
+ */
+export const canDropIntoScope = (
+  item: NewUISchemaElement,
+  scopeUISchemaElement: LinkedUISchemaElement | undefined
+) => {
+  // it's a control when there is a schema
+  if (item.schema) {
+    // check wether the control fits to the scope
+    // -- TODO check other cases than array
+    const scopeSchemaElement = getArrayContainer(item.schema);
+    if (!!scopeSchemaElement !== !!scopeUISchemaElement) {
+      // scopes don't match when one exist and the other doesn't
+      return false;
+    }
+    if (
+      scopeSchemaElement &&
+      scopeUISchemaElement &&
+      scopeUISchemaElement.linkedSchemaElement !== scopeSchemaElement.uuid
+    ) {
+      // scopes didn't match
+      return false;
+    }
+  }
+  return true;
+};
+
+export const canMoveSchemaElementTo = (
+  item: MoveUISchemaElement,
+  layout: LinkedUISchemaElement,
+  index: number
+) => {
+  const uiElementToMove = item.uiSchemaElement as LinkedUISchemaElement;
+  // can't move the root element
+  if (!uiElementToMove.parent) {
+    return false;
+  }
+  // can't move element into itself
+  if (getHierarchy(layout).includes(uiElementToMove)) {
+    return false;
+  }
+  // can't move element next to itself (which would result in no change)
+  if (layout === uiElementToMove.parent) {
+    const currentIndex = (uiElementToMove.parent as LinkedLayout).elements.indexOf(
+      uiElementToMove
+    );
+    if (currentIndex === index || currentIndex === index - 1) {
+      return false;
+    }
+  }
+  // controls can't move across scope barriers
+  if (
+    containsControls(uiElementToMove) &&
+    getDetailContainer(uiElementToMove) !== getDetailContainer(layout)
+  ) {
+    return false;
+  }
+  return true;
+};

--- a/src/core/icons/icons.tsx
+++ b/src/core/icons/icons.tsx
@@ -59,3 +59,10 @@ interface UISchemaIconProps {
 export const UISchemaIcon: React.FC<UISchemaIconProps> = ({ type }) => {
   return React.createElement(getIconForUISchemaType(type), {});
 };
+
+interface SchemaIconProps {
+  type: SchemaElementType;
+}
+export const SchemaIcon: React.FC<SchemaIconProps> = ({ type }) => {
+  return React.createElement(getIconForSchemaType(type), {});
+};

--- a/src/core/model/actions.ts
+++ b/src/core/model/actions.ts
@@ -5,10 +5,8 @@
  * https://github.com/eclipsesource/jsonforms-editor/blob/master/LICENSE
  * ---------------------------------------------------------------------
  */
-import { Layout } from '@jsonforms/core';
-
 import { SchemaElement } from './schema';
-import { LinkedUISchemaElement } from './uischema';
+import { LinkedLayout, LinkedUISchemaElement } from './uischema';
 
 export type SchemaAction = SetSchemaAction;
 export type UiSchemaAction =
@@ -19,7 +17,8 @@ export type CombinedAction =
   | SetSchemasAction
   | AddScopedElementToLayout
   | MoveUiSchemaElement
-  | RemoveUiSchemaElement;
+  | RemoveUiSchemaElement
+  | AddDetail;
 
 export type EditorAction = SchemaAction | UiSchemaAction | CombinedAction;
 
@@ -29,7 +28,6 @@ export const SET_UISCHEMA: 'jsonforms-editor/SET_UISCHEMA' =
   'jsonforms-editor/SET_UISCHEMA';
 export const SET_SCHEMAS: 'jsonforms-editor/SET_SCHEMAS' =
   'jsonforms-editor/SET_SCHEMAS';
-/** UI schema actions */
 export const ADD_SCOPED_ELEMENT_TO_LAYOUT: 'jsonforms-editor/ADD_SCOPED_ELEMENT_TO_LAYOUT' =
   'jsonforms-editor/ADD_SCOPED_ELEMENT_TO_LAYOUT';
 export const ADD_UNSCOPED_ELEMENT_TO_LAYOUT: 'jsonforms-editor/ADD_UNSCOPED_ELEMENT_TO_LAYOUT' =
@@ -40,6 +38,8 @@ export const REMOVE_UISCHEMA_ELEMENT: 'jsonforms-editor/REMOVE_UISCHEMA_ELEMENT'
   'jsonforms-editor/REMOVE_UISCHEMA_ELEMENT';
 export const SET_UISCHEMA_OPTIONS: 'jsonforms-editor/SET_UISCHEMA_OPTIONS' =
   'jsonforms-editor/SET_UISCHEMA_OPTIONS';
+export const ADD_DETAIL: 'jsonforms-editor/ADD_DETAIL' =
+  'jsonforms-editor/ADD_DETAIL';
 
 export interface SetSchemaAction {
   type: 'jsonforms-editor/SET_SCHEMA';
@@ -60,20 +60,22 @@ export interface SetSchemasAction {
 export interface AddScopedElementToLayout {
   type: 'jsonforms-editor/ADD_SCOPED_ELEMENT_TO_LAYOUT';
   uiSchemaElement: LinkedUISchemaElement;
-  layout: Layout;
+  layout: LinkedLayout;
   schema: SchemaElement;
   index: number;
 }
+
 export interface AddUnscopedElementToLayout {
   type: 'jsonforms-editor/ADD_UNSCOPED_ELEMENT_TO_LAYOUT';
   uiSchemaElement: LinkedUISchemaElement;
-  layout: Layout;
+  layout: LinkedLayout;
   index: number;
 }
+
 export interface MoveUiSchemaElement {
   type: 'jsonforms-editor/MOVE_UISCHEMA_ELEMENT';
   uiSchemaElement: LinkedUISchemaElement;
-  layout: Layout;
+  newContainer: LinkedUISchemaElement;
   index: number;
   schema?: SchemaElement;
 }
@@ -87,6 +89,12 @@ export interface SetUISchemaOptions {
   type: 'jsonforms-editor/SET_UISCHEMA_OPTIONS';
   uiSchema: LinkedUISchemaElement;
   options: { [key: string]: any };
+}
+
+export interface AddDetail {
+  type: 'jsonforms-editor/ADD_DETAIL';
+  uiSchemaElementId: string;
+  detail: LinkedUISchemaElement;
 }
 
 const setSchema = (schema: any) => ({
@@ -107,7 +115,7 @@ const setSchemas = (schema: any, uiSchema: any) => ({
 
 const addScopedElementToLayout = (
   uiSchemaElement: LinkedUISchemaElement,
-  layout: Layout,
+  layout: LinkedLayout,
   index: number,
   schema: any
 ) => ({
@@ -120,7 +128,7 @@ const addScopedElementToLayout = (
 
 const addUnscopedElementToLayout = (
   uiSchemaElement: LinkedUISchemaElement,
-  layout: Layout,
+  layout: LinkedLayout,
   index: number
 ) => ({
   type: ADD_UNSCOPED_ELEMENT_TO_LAYOUT,
@@ -131,13 +139,13 @@ const addUnscopedElementToLayout = (
 
 const moveUiSchemaElement = (
   uiSchemaElement: LinkedUISchemaElement,
-  layout: Layout,
+  newContainer: LinkedUISchemaElement,
   index: number,
   schema?: SchemaElement
 ) => ({
   type: MOVE_UISCHEMA_ELEMENT,
   uiSchemaElement,
-  layout,
+  newContainer,
   index,
   schema,
 });
@@ -152,6 +160,15 @@ const setUiSchemaOptions = (
   options: { [key: string]: any }
 ) => ({ type: SET_UISCHEMA_OPTIONS, uiSchema, options });
 
+const addDetail = (
+  uiSchemaElementId: string,
+  detail: LinkedUISchemaElement
+) => ({
+  type: ADD_DETAIL,
+  uiSchemaElementId,
+  detail,
+});
+
 export const Actions = {
   setSchema,
   setUiSchema,
@@ -161,4 +178,5 @@ export const Actions = {
   moveUiSchemaElement,
   removeUiSchemaElement,
   setUiSchemaOptions,
+  addDetail,
 };

--- a/src/core/model/actions.ts
+++ b/src/core/model/actions.ts
@@ -6,7 +6,7 @@
  * ---------------------------------------------------------------------
  */
 import { SchemaElement } from './schema';
-import { LinkedLayout, LinkedUISchemaElement } from './uischema';
+import { EditorLayout, EditorUISchemaElement } from './uischema';
 
 export type SchemaAction = SetSchemaAction;
 export type UiSchemaAction =
@@ -59,42 +59,42 @@ export interface SetSchemasAction {
 
 export interface AddScopedElementToLayout {
   type: 'jsonforms-editor/ADD_SCOPED_ELEMENT_TO_LAYOUT';
-  uiSchemaElement: LinkedUISchemaElement;
-  layout: LinkedLayout;
+  uiSchemaElement: EditorUISchemaElement;
+  layout: EditorLayout;
   schema: SchemaElement;
   index: number;
 }
 
 export interface AddUnscopedElementToLayout {
   type: 'jsonforms-editor/ADD_UNSCOPED_ELEMENT_TO_LAYOUT';
-  uiSchemaElement: LinkedUISchemaElement;
-  layout: LinkedLayout;
+  uiSchemaElement: EditorUISchemaElement;
+  layout: EditorLayout;
   index: number;
 }
 
 export interface MoveUiSchemaElement {
   type: 'jsonforms-editor/MOVE_UISCHEMA_ELEMENT';
-  uiSchemaElement: LinkedUISchemaElement;
-  newContainer: LinkedUISchemaElement;
+  uiSchemaElement: EditorUISchemaElement;
+  newContainer: EditorUISchemaElement;
   index: number;
   schema?: SchemaElement;
 }
 
 export interface RemoveUiSchemaElement {
   type: 'jsonforms-editor/REMOVE_UISCHEMA_ELEMENT';
-  uiSchemaElement: LinkedUISchemaElement;
+  uiSchemaElement: EditorUISchemaElement;
 }
 
 export interface SetUISchemaOptions {
   type: 'jsonforms-editor/SET_UISCHEMA_OPTIONS';
-  uiSchema: LinkedUISchemaElement;
+  uiSchema: EditorUISchemaElement;
   options: { [key: string]: any };
 }
 
 export interface AddDetail {
   type: 'jsonforms-editor/ADD_DETAIL';
   uiSchemaElementId: string;
-  detail: LinkedUISchemaElement;
+  detail: EditorUISchemaElement;
 }
 
 const setSchema = (schema: any) => ({
@@ -114,8 +114,8 @@ const setSchemas = (schema: any, uiSchema: any) => ({
 });
 
 const addScopedElementToLayout = (
-  uiSchemaElement: LinkedUISchemaElement,
-  layout: LinkedLayout,
+  uiSchemaElement: EditorUISchemaElement,
+  layout: EditorLayout,
   index: number,
   schema: any
 ) => ({
@@ -127,8 +127,8 @@ const addScopedElementToLayout = (
 });
 
 const addUnscopedElementToLayout = (
-  uiSchemaElement: LinkedUISchemaElement,
-  layout: LinkedLayout,
+  uiSchemaElement: EditorUISchemaElement,
+  layout: EditorLayout,
   index: number
 ) => ({
   type: ADD_UNSCOPED_ELEMENT_TO_LAYOUT,
@@ -138,8 +138,8 @@ const addUnscopedElementToLayout = (
 });
 
 const moveUiSchemaElement = (
-  uiSchemaElement: LinkedUISchemaElement,
-  newContainer: LinkedUISchemaElement,
+  uiSchemaElement: EditorUISchemaElement,
+  newContainer: EditorUISchemaElement,
   index: number,
   schema?: SchemaElement
 ) => ({
@@ -150,19 +150,19 @@ const moveUiSchemaElement = (
   schema,
 });
 
-const removeUiSchemaElement = (uiSchemaElement: LinkedUISchemaElement) => ({
+const removeUiSchemaElement = (uiSchemaElement: EditorUISchemaElement) => ({
   type: REMOVE_UISCHEMA_ELEMENT,
   uiSchemaElement,
 });
 
 const setUiSchemaOptions = (
-  uiSchema: LinkedUISchemaElement,
+  uiSchema: EditorUISchemaElement,
   options: { [key: string]: any }
 ) => ({ type: SET_UISCHEMA_OPTIONS, uiSchema, options });
 
 const addDetail = (
   uiSchemaElementId: string,
-  detail: LinkedUISchemaElement
+  detail: EditorUISchemaElement
 ) => ({
   type: ADD_DETAIL,
   uiSchemaElementId,

--- a/src/core/model/reducer.test.ts
+++ b/src/core/model/reducer.test.ts
@@ -16,15 +16,15 @@ import {
   SchemaElement,
 } from './schema';
 import {
-  buildLinkedUiSchemaTree,
-  LinkedLayout,
-  LinkedUISchemaElement,
+  buildEditorUiSchemaTree,
+  EditorLayout,
+  EditorUISchemaElement,
 } from './uischema';
 
 describe('add detail action', () => {
   const buildState = (): {
     schema: SchemaElement;
-    uiSchema: LinkedUISchemaElement;
+    uiSchema: EditorUISchemaElement;
   } => {
     const schema = buildSchemaTree({
       type: 'object',
@@ -42,13 +42,13 @@ describe('add detail action', () => {
         },
       },
     }) as ObjectElement;
-    const uiSchema = buildLinkedUiSchemaTree({
+    const uiSchema = buildEditorUiSchemaTree({
       type: 'VerticalLayout',
       elements: [
         { type: 'Control', scope: '#/properties/toys' } as ControlElement,
       ],
-    } as Layout) as LinkedLayout;
-    schema.properties.get('toys')!.linkedUiSchemaElements = new Set(
+    } as Layout) as EditorLayout;
+    schema.properties.get('toys')!.linkedUISchemaElements = new Set(
       uiSchema.elements[0].uuid
     );
     uiSchema.elements[0].linkedSchemaElement = schema.properties.get(
@@ -59,12 +59,12 @@ describe('add detail action', () => {
 
   test('add non-scoped ui schema element as detail', () => {
     const { schema, uiSchema } = buildState();
-    const newDetail = buildLinkedUiSchemaTree({
+    const newDetail = buildEditorUiSchemaTree({
       type: 'HorizontalLayout',
       elements: [],
     } as Layout);
     const addDetailAction = Actions.addDetail(
-      (uiSchema as LinkedLayout).elements[0].uuid,
+      (uiSchema as EditorLayout).elements[0].uuid,
       newDetail
     );
     const { uiSchema: newUiSchema } = combinedReducer(
@@ -72,13 +72,13 @@ describe('add detail action', () => {
       addDetailAction
     );
     expect(
-      (newUiSchema as LinkedLayout).elements[0].options!.detail
+      (newUiSchema as EditorLayout).elements[0].options!.detail
     ).toStrictEqual(newDetail);
   });
 
   test('add scoped ui schema element as detail', () => {
     const { schema, uiSchema } = buildState();
-    const newDetail = buildLinkedUiSchemaTree({
+    const newDetail = buildEditorUiSchemaTree({
       type: 'Control',
       scope: '#/properties/height',
     } as ControlElement);
@@ -86,7 +86,7 @@ describe('add detail action', () => {
       'toys'
     ) as ArrayElement).items as ObjectElement).properties.get('height')!.uuid;
     const addDetailAction = Actions.addDetail(
-      (uiSchema as LinkedLayout).elements[0].uuid,
+      (uiSchema as EditorLayout).elements[0].uuid,
       newDetail
     );
     const { schema: newSchema, uiSchema: newUiSchema } = combinedReducer(
@@ -94,13 +94,13 @@ describe('add detail action', () => {
       addDetailAction
     );
     expect(
-      (newUiSchema as LinkedLayout).elements[0].options!.detail
+      (newUiSchema as EditorLayout).elements[0].options!.detail
     ).toStrictEqual(newDetail);
     expect(
       (((newSchema as ObjectElement).properties.get('toys') as ArrayElement)
         .items as ObjectElement).properties
         .get('height')!
-        .linkedUiSchemaElements!.has(newDetail.uuid)
+        .linkedUISchemaElements!.has(newDetail.uuid)
     ).toBeTruthy();
   });
 });

--- a/src/core/model/reducer.test.ts
+++ b/src/core/model/reducer.test.ts
@@ -1,0 +1,106 @@
+/**
+ * ---------------------------------------------------------------------
+ * Copyright (c) 2020 EclipseSource Munich
+ * Licensed under MIT
+ * https://github.com/eclipsesource/jsonforms-editor/blob/master/LICENSE
+ * ---------------------------------------------------------------------
+ */
+import { ControlElement, Layout } from '@jsonforms/core';
+
+import { Actions } from './actions';
+import { combinedReducer } from './reducer';
+import {
+  ArrayElement,
+  buildSchemaTree,
+  ObjectElement,
+  SchemaElement,
+} from './schema';
+import {
+  buildLinkedUiSchemaTree,
+  LinkedLayout,
+  LinkedUISchemaElement,
+} from './uischema';
+
+describe('add detail action', () => {
+  const buildState = (): {
+    schema: SchemaElement;
+    uiSchema: LinkedUISchemaElement;
+  } => {
+    const schema = buildSchemaTree({
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        toys: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              name: { type: 'string' },
+              height: { type: 'number' },
+            },
+          },
+        },
+      },
+    }) as ObjectElement;
+    const uiSchema = buildLinkedUiSchemaTree({
+      type: 'VerticalLayout',
+      elements: [
+        { type: 'Control', scope: '#/properties/toys' } as ControlElement,
+      ],
+    } as Layout) as LinkedLayout;
+    schema.properties.get('toys')!.linkedUiSchemaElements = new Set(
+      uiSchema.elements[0].uuid
+    );
+    uiSchema.elements[0].linkedSchemaElement = schema.properties.get(
+      'toys'
+    )!.uuid;
+    return { schema, uiSchema };
+  };
+
+  test('add non-scoped ui schema element as detail', () => {
+    const { schema, uiSchema } = buildState();
+    const newDetail = buildLinkedUiSchemaTree({
+      type: 'HorizontalLayout',
+      elements: [],
+    } as Layout);
+    const addDetailAction = Actions.addDetail(
+      (uiSchema as LinkedLayout).elements[0].uuid,
+      newDetail
+    );
+    const { uiSchema: newUiSchema } = combinedReducer(
+      { schema, uiSchema },
+      addDetailAction
+    );
+    expect(
+      (newUiSchema as LinkedLayout).elements[0].options!.detail
+    ).toStrictEqual(newDetail);
+  });
+
+  test('add scoped ui schema element as detail', () => {
+    const { schema, uiSchema } = buildState();
+    const newDetail = buildLinkedUiSchemaTree({
+      type: 'Control',
+      scope: '#/properties/height',
+    } as ControlElement);
+    newDetail.linkedSchemaElement = (((schema as ObjectElement).properties.get(
+      'toys'
+    ) as ArrayElement).items as ObjectElement).properties.get('height')!.uuid;
+    const addDetailAction = Actions.addDetail(
+      (uiSchema as LinkedLayout).elements[0].uuid,
+      newDetail
+    );
+    const { schema: newSchema, uiSchema: newUiSchema } = combinedReducer(
+      { schema, uiSchema },
+      addDetailAction
+    );
+    expect(
+      (newUiSchema as LinkedLayout).elements[0].options!.detail
+    ).toStrictEqual(newDetail);
+    expect(
+      (((newSchema as ObjectElement).properties.get('toys') as ArrayElement)
+        .items as ObjectElement).properties
+        .get('height')!
+        .linkedUiSchemaElements!.has(newDetail.uuid)
+    ).toBeTruthy();
+  });
+});

--- a/src/core/model/schema.test.ts
+++ b/src/core/model/schema.test.ts
@@ -1,0 +1,81 @@
+/**
+ * ---------------------------------------------------------------------
+ * Copyright (c) 2020 EclipseSource Munich
+ * Licensed under MIT
+ * https://github.com/eclipsesource/jsonforms-editor/blob/master/LICENSE
+ * ---------------------------------------------------------------------
+ */
+
+import {
+  buildSchemaTree,
+  getArrayContainer,
+  getChildren,
+  SchemaElement,
+} from './schema';
+
+test('set uuids on single element', () => {
+  const element = simplePrimitive();
+  const enrichedElement = buildSchemaTree(element);
+  expect(enrichedElement).toHaveProperty('uuid');
+});
+
+test('set uuids on nested elements', () => {
+  const object = simpleObject();
+  const enrichedObject = buildSchemaTree(object) as SchemaElement;
+  expect(enrichedObject).toHaveProperty('uuid');
+  const children = getChildren(enrichedObject);
+  expect(children.length).toBe(2);
+  children.forEach((child) => {
+    expect(child).toHaveProperty('uuid');
+  });
+});
+
+test('getArrayContainer', () => {
+  const array = simpleArray();
+  (array as any).items.properties.nestedArray = simpleArray();
+
+  const enrichedArray = buildSchemaTree(array) as SchemaElement;
+  expect(enrichedArray).toBeTruthy();
+  expect(getArrayContainer(enrichedArray!)).toBeFalsy();
+
+  const arrayChildren = getChildren(enrichedArray);
+  expect(arrayChildren.length).toBe(1);
+
+  const object = arrayChildren[0];
+  expect(getArrayContainer(object)).toBe(enrichedArray);
+
+  const objectChildren = getChildren(object);
+  expect(objectChildren.length).toBe(3);
+  objectChildren.forEach((child) => {
+    expect(getArrayContainer(child)).toBe(enrichedArray);
+  });
+
+  const nestedArray = objectChildren[2];
+
+  const nestedArrayChildren = getChildren(nestedArray);
+  expect(nestedArrayChildren.length).toBe(1);
+
+  const nestedArrayObject = nestedArrayChildren[0];
+  expect(getArrayContainer(nestedArrayObject)).toBe(nestedArray);
+
+  getChildren(nestedArrayObject).forEach((child) => {
+    expect(getArrayContainer(child)).toBe(nestedArray);
+  });
+});
+
+const simplePrimitive = () => ({
+  type: 'string',
+});
+
+const simpleObject = () => ({
+  type: 'object',
+  properties: {
+    name: simplePrimitive(),
+    surname: simplePrimitive(),
+  },
+});
+
+const simpleArray = () => ({
+  type: 'array',
+  items: simpleObject(),
+});

--- a/src/core/model/schema.ts
+++ b/src/core/model/schema.ts
@@ -22,7 +22,7 @@ interface SchemaElementBase extends TreeElement<SchemaElement> {
   type: SchemaElementType;
   schema: any;
   other?: Map<string, SchemaElement>;
-  linkedUiSchemaElements?: Set<string>;
+  linkedUISchemaElements?: Set<string>;
 }
 
 export type SchemaElement =

--- a/src/core/model/uischema.test.ts
+++ b/src/core/model/uischema.test.ts
@@ -1,0 +1,85 @@
+/**
+ * ---------------------------------------------------------------------
+ * Copyright (c) 2020 EclipseSource Munich
+ * Licensed under MIT
+ * https://github.com/eclipsesource/jsonforms-editor/blob/master/LICENSE
+ * ---------------------------------------------------------------------
+ */
+import { ControlElement } from '@jsonforms/core';
+
+import { getRoot } from '../util/clone';
+import {
+  buildLinkedUiSchemaTree,
+  containsControls,
+  getDetailContainer,
+  LinkedLayout,
+} from './uischema';
+
+test('set uuids on single element', () => {
+  const element = simpleControl();
+  const enrichedElement = buildLinkedUiSchemaTree(element);
+  expect(enrichedElement).toHaveProperty('uuid');
+});
+
+test('set uuids on nested elements', () => {
+  const layout = simpleLayout();
+  const enrichedLayout = buildLinkedUiSchemaTree(layout) as LinkedLayout;
+  expect(enrichedLayout).toHaveProperty('uuid');
+  expect(enrichedLayout.elements[0]).toHaveProperty('uuid');
+  expect(enrichedLayout.elements[1]).toHaveProperty('uuid');
+});
+
+test('set uuids on detail', () => {
+  const controlWithDetail = simpleControl();
+  controlWithDetail.options = { detail: simpleLayout() };
+  const enrichedLayout = buildLinkedUiSchemaTree(controlWithDetail);
+  expect(enrichedLayout).toHaveProperty('uuid');
+  expect(enrichedLayout.options!.detail.elements[0]).toHaveProperty('uuid');
+  expect(enrichedLayout.options!.detail.elements[1]).toHaveProperty('uuid');
+});
+
+test('set parent on detail', () => {
+  const controlWithDetail = simpleControl();
+  controlWithDetail.options = { detail: simpleLayout() };
+  const enrichedLayout = buildLinkedUiSchemaTree(controlWithDetail);
+  expect(getRoot(enrichedLayout.options!.detail)).toBe(enrichedLayout);
+  expect(getRoot(enrichedLayout.options!.detail.elements[0])).toBe(
+    enrichedLayout
+  );
+});
+
+test('isInDetail', () => {
+  const controlWithDetail = simpleControl();
+  controlWithDetail.options = { detail: simpleLayout() };
+  const enrichedControlWithDetail = buildLinkedUiSchemaTree(controlWithDetail);
+  expect(getDetailContainer(enrichedControlWithDetail)).toBeFalsy();
+  expect(getDetailContainer(enrichedControlWithDetail.options!.detail)).toBe(
+    enrichedControlWithDetail
+  );
+  expect(
+    getDetailContainer(enrichedControlWithDetail.options!.detail.elements[0])
+  ).toBe(enrichedControlWithDetail);
+});
+
+test('containsControls', () => {
+  expect(containsControls(simpleLinkedControl())).toBeTruthy();
+  const layout = simpleLinkedLayout();
+  expect(containsControls(layout)).toBeTruthy();
+  layout.elements = [];
+  expect(containsControls(layout)).toBeFalsy();
+});
+
+const simpleControl = (): ControlElement => ({
+  type: 'Control',
+  scope: '#',
+});
+
+const simpleLayout = () => ({
+  type: 'VerticalLayout',
+  elements: [simpleControl(), simpleControl()],
+});
+
+const simpleLinkedControl = () => buildLinkedUiSchemaTree(simpleControl());
+
+const simpleLinkedLayout = (): LinkedLayout =>
+  buildLinkedUiSchemaTree(simpleLayout()) as LinkedLayout;

--- a/src/core/model/uischema.test.ts
+++ b/src/core/model/uischema.test.ts
@@ -9,21 +9,21 @@ import { ControlElement } from '@jsonforms/core';
 
 import { getRoot } from '../util/clone';
 import {
-  buildLinkedUiSchemaTree,
+  buildEditorUiSchemaTree,
   containsControls,
+  EditorLayout,
   getDetailContainer,
-  LinkedLayout,
 } from './uischema';
 
 test('set uuids on single element', () => {
   const element = simpleControl();
-  const enrichedElement = buildLinkedUiSchemaTree(element);
+  const enrichedElement = buildEditorUiSchemaTree(element);
   expect(enrichedElement).toHaveProperty('uuid');
 });
 
 test('set uuids on nested elements', () => {
   const layout = simpleLayout();
-  const enrichedLayout = buildLinkedUiSchemaTree(layout) as LinkedLayout;
+  const enrichedLayout = buildEditorUiSchemaTree(layout) as EditorLayout;
   expect(enrichedLayout).toHaveProperty('uuid');
   expect(enrichedLayout.elements[0]).toHaveProperty('uuid');
   expect(enrichedLayout.elements[1]).toHaveProperty('uuid');
@@ -32,7 +32,7 @@ test('set uuids on nested elements', () => {
 test('set uuids on detail', () => {
   const controlWithDetail = simpleControl();
   controlWithDetail.options = { detail: simpleLayout() };
-  const enrichedLayout = buildLinkedUiSchemaTree(controlWithDetail);
+  const enrichedLayout = buildEditorUiSchemaTree(controlWithDetail);
   expect(enrichedLayout).toHaveProperty('uuid');
   expect(enrichedLayout.options!.detail.elements[0]).toHaveProperty('uuid');
   expect(enrichedLayout.options!.detail.elements[1]).toHaveProperty('uuid');
@@ -41,7 +41,7 @@ test('set uuids on detail', () => {
 test('set parent on detail', () => {
   const controlWithDetail = simpleControl();
   controlWithDetail.options = { detail: simpleLayout() };
-  const enrichedLayout = buildLinkedUiSchemaTree(controlWithDetail);
+  const enrichedLayout = buildEditorUiSchemaTree(controlWithDetail);
   expect(getRoot(enrichedLayout.options!.detail)).toBe(enrichedLayout);
   expect(getRoot(enrichedLayout.options!.detail.elements[0])).toBe(
     enrichedLayout
@@ -51,7 +51,7 @@ test('set parent on detail', () => {
 test('isInDetail', () => {
   const controlWithDetail = simpleControl();
   controlWithDetail.options = { detail: simpleLayout() };
-  const enrichedControlWithDetail = buildLinkedUiSchemaTree(controlWithDetail);
+  const enrichedControlWithDetail = buildEditorUiSchemaTree(controlWithDetail);
   expect(getDetailContainer(enrichedControlWithDetail)).toBeFalsy();
   expect(getDetailContainer(enrichedControlWithDetail.options!.detail)).toBe(
     enrichedControlWithDetail
@@ -62,8 +62,8 @@ test('isInDetail', () => {
 });
 
 test('containsControls', () => {
-  expect(containsControls(simpleLinkedControl())).toBeTruthy();
-  const layout = simpleLinkedLayout();
+  expect(containsControls(simpleEditorControl())).toBeTruthy();
+  const layout = simpleEditorLayout();
   expect(containsControls(layout)).toBeTruthy();
   layout.elements = [];
   expect(containsControls(layout)).toBeFalsy();
@@ -79,7 +79,7 @@ const simpleLayout = () => ({
   elements: [simpleControl(), simpleControl()],
 });
 
-const simpleLinkedControl = () => buildLinkedUiSchemaTree(simpleControl());
+const simpleEditorControl = () => buildEditorUiSchemaTree(simpleControl());
 
-const simpleLinkedLayout = (): LinkedLayout =>
-  buildLinkedUiSchemaTree(simpleLayout()) as LinkedLayout;
+const simpleEditorLayout = (): EditorLayout =>
+  buildEditorUiSchemaTree(simpleLayout()) as EditorLayout;

--- a/src/core/model/uischema.ts
+++ b/src/core/model/uischema.ts
@@ -18,49 +18,49 @@ import { v4 as uuid } from 'uuid';
 import { calculatePath, getRoot, isPathError, PathError } from '../util/clone';
 import { getHierarchy, TreeElement } from '../util/tree';
 
-export interface LinkedUISchemaElement
+export interface EditorUISchemaElement
   extends UISchemaElement,
-    TreeElement<LinkedUISchemaElement> {
+    TreeElement<EditorUISchemaElement> {
   linkedSchemaElement?: string;
 }
 
-export interface LinkedControl extends ControlElement, LinkedUISchemaElement {
+export interface EditorControl extends ControlElement, EditorUISchemaElement {
   type: 'Control';
 }
 
-export interface LinkedLayout extends Layout, LinkedUISchemaElement {
-  elements: LinkedUISchemaElement[];
+export interface EditorLayout extends Layout, EditorUISchemaElement {
+  elements: EditorUISchemaElement[];
 }
 
-const isLinkedUISchemaElement = (
+const isEditorUISchemaElement = (
   element: any
-): element is LinkedUISchemaElement => {
+): element is EditorUISchemaElement => {
   return !!element?.type && !!element?.uuid;
 };
 
-export const isLinkedControl = (
+export const isEditorControl = (
   element: UISchemaElement
-): element is LinkedControl => {
-  return isLinkedUISchemaElement(element) && isControl(element);
+): element is EditorControl => {
+  return isEditorUISchemaElement(element) && isControl(element);
 };
 
-export const isLinkedLayout = (
+export const isEditorLayout = (
   element: UISchemaElement
-): element is LinkedLayout => {
-  return isLinkedUISchemaElement(element) && isLayout(element);
+): element is EditorLayout => {
+  return isEditorUISchemaElement(element) && isLayout(element);
 };
 
 export const getChildren = (
-  schemaElement: LinkedUISchemaElement
-): Array<LinkedUISchemaElement> => {
-  const children: Array<LinkedUISchemaElement> = [];
-  if (isLinkedLayout(schemaElement)) {
+  schemaElement: EditorUISchemaElement
+): Array<EditorUISchemaElement> => {
+  const children: Array<EditorUISchemaElement> = [];
+  if (isEditorLayout(schemaElement)) {
     children.push(...schemaElement.elements);
   }
   return children;
 };
 
-export const hasChildren = (schemaElement: LinkedUISchemaElement): boolean => {
+export const hasChildren = (schemaElement: EditorUISchemaElement): boolean => {
   return isLayout(schemaElement) && !!(schemaElement as Layout).elements.length;
 };
 
@@ -68,18 +68,18 @@ export const hasChildren = (schemaElement: LinkedUISchemaElement): boolean => {
  * Creates a copy of the given ui schema enriched with editor fields
  * like 'parent' and 'linked schema elements'.
  */
-export const buildLinkedUiSchemaTree = (
+export const buildEditorUiSchemaTree = (
   uiSchema: UISchemaElement
-): LinkedUISchemaElement => {
+): EditorUISchemaElement => {
   // cast to any so we can freely modify it
-  const linkedUiSchema: any = cloneDeep(uiSchema);
-  traverse(linkedUiSchema, (current, parent) => {
+  const editorUiSchema: any = cloneDeep(uiSchema);
+  traverse(editorUiSchema, (current, parent) => {
     if (current) {
       current.parent = parent;
       current.uuid = uuid();
     }
   });
-  return linkedUiSchema;
+  return editorUiSchema;
 };
 
 /**
@@ -87,9 +87,9 @@ export const buildLinkedUiSchemaTree = (
  * related fields.
  */
 export const buildUiSchema = (
-  uiSchema: LinkedUISchemaElement
+  uiSchema: EditorUISchemaElement
 ): UISchemaElement => {
-  const clone: LinkedUISchemaElement = cloneDeep(uiSchema);
+  const clone: EditorUISchemaElement = cloneDeep(uiSchema);
   traverse(clone, (current) => {
     delete current.parent;
     delete current.linkedSchemaElement;
@@ -124,7 +124,7 @@ const doTraverse = <T extends UISchemaElement, C>(
 };
 
 export const getUISchemaPath = (
-  uiSchema: LinkedUISchemaElement
+  uiSchema: EditorUISchemaElement
 ): string | PathError => {
   const root = getRoot(uiSchema);
   const path = calculatePath(root, uiSchema);
@@ -139,9 +139,9 @@ export const getUISchemaPath = (
  * Returns the closes element whose detail contains the given element
  */
 export const getDetailContainer = (
-  element: LinkedUISchemaElement
-): LinkedUISchemaElement | undefined => {
-  const parentIsDetail = (el: LinkedUISchemaElement) =>
+  element: EditorUISchemaElement
+): EditorUISchemaElement | undefined => {
+  const parentIsDetail = (el: EditorUISchemaElement) =>
     el.parent?.options?.detail === el;
   return getHierarchy(element).find(parentIsDetail)?.parent;
 };
@@ -149,11 +149,11 @@ export const getDetailContainer = (
 /**
  * Indicates whether the given ui schema element is a control or contains controls
  */
-export const containsControls = (element: LinkedUISchemaElement): boolean =>
+export const containsControls = (element: EditorUISchemaElement): boolean =>
   traverse(
     element,
     (el, _parent, acc) => {
-      if (isLinkedControl(el)) {
+      if (isEditorControl(el)) {
         acc.containsControls = true;
       }
     },

--- a/src/core/model/uischema.ts
+++ b/src/core/model/uischema.ts
@@ -5,23 +5,56 @@
  * https://github.com/eclipsesource/jsonforms-editor/blob/master/LICENSE
  * ---------------------------------------------------------------------
  */
-import { isLayout, Layout, UISchemaElement } from '@jsonforms/core';
+import {
+  ControlElement,
+  isControl,
+  isLayout,
+  Layout,
+  UISchemaElement,
+} from '@jsonforms/core';
 import { cloneDeep } from 'lodash';
 import { v4 as uuid } from 'uuid';
 
 import { calculatePath, getRoot, isPathError, PathError } from '../util/clone';
+import { getHierarchy, TreeElement } from '../util/tree';
 
-export interface LinkedUISchemaElement extends UISchemaElement {
+export interface LinkedUISchemaElement
+  extends UISchemaElement,
+    TreeElement<LinkedUISchemaElement> {
   linkedSchemaElement?: string;
-  parent?: LinkedUISchemaElement;
-  uuid?: string;
 }
+
+export interface LinkedControl extends ControlElement, LinkedUISchemaElement {
+  type: 'Control';
+}
+
+export interface LinkedLayout extends Layout, LinkedUISchemaElement {
+  elements: LinkedUISchemaElement[];
+}
+
+const isLinkedUISchemaElement = (
+  element: any
+): element is LinkedUISchemaElement => {
+  return !!element?.type && !!element?.uuid;
+};
+
+export const isLinkedControl = (
+  element: UISchemaElement
+): element is LinkedControl => {
+  return isLinkedUISchemaElement(element) && isControl(element);
+};
+
+export const isLinkedLayout = (
+  element: UISchemaElement
+): element is LinkedLayout => {
+  return isLinkedUISchemaElement(element) && isLayout(element);
+};
 
 export const getChildren = (
   schemaElement: LinkedUISchemaElement
 ): Array<LinkedUISchemaElement> => {
   const children: Array<LinkedUISchemaElement> = [];
-  if (isLayout(schemaElement)) {
+  if (isLinkedLayout(schemaElement)) {
     children.push(...schemaElement.elements);
   }
   return children;
@@ -38,7 +71,8 @@ export const hasChildren = (schemaElement: LinkedUISchemaElement): boolean => {
 export const buildLinkedUiSchemaTree = (
   uiSchema: UISchemaElement
 ): LinkedUISchemaElement => {
-  const linkedUiSchema: LinkedUISchemaElement = cloneDeep(uiSchema);
+  // cast to any so we can freely modify it
+  const linkedUiSchema: any = cloneDeep(uiSchema);
   traverse(linkedUiSchema, (current, parent) => {
     if (current) {
       current.parent = parent;
@@ -56,7 +90,7 @@ export const buildUiSchema = (
   uiSchema: LinkedUISchemaElement
 ): UISchemaElement => {
   const clone: LinkedUISchemaElement = cloneDeep(uiSchema);
-  traverse(clone, (current, parent) => {
+  traverse(clone, (current) => {
     delete current.parent;
     delete current.linkedSchemaElement;
     delete current.uuid;
@@ -64,19 +98,29 @@ export const buildUiSchema = (
   return clone;
 };
 
-const traverse = (
-  uiSchema: LinkedUISchemaElement,
-  pre: (
-    uiSchema: LinkedUISchemaElement,
-    parent?: LinkedUISchemaElement
-  ) => void,
-  parent?: LinkedUISchemaElement
-): void => {
-  pre(uiSchema, parent);
+export const traverse = <T extends UISchemaElement, C>(
+  uiSchema: T,
+  pre: (uiSchema: T, parent: T | undefined, context: C) => void,
+  context?: C
+): C => doTraverse(uiSchema, pre, undefined, context!);
+
+const doTraverse = <T extends UISchemaElement, C>(
+  uiSchema: T,
+  pre: (uiSchema: T, parent: T | undefined, context: C) => void,
+  parent: T | undefined,
+  context: C
+): C => {
+  pre(uiSchema, parent, context);
   if (uiSchema && isLayout(uiSchema)) {
-    uiSchema.elements.forEach((el) => traverse(el, pre, uiSchema));
+    uiSchema.elements.forEach((el) =>
+      doTraverse(el as T, pre, uiSchema, context)
+    );
+  }
+  if (uiSchema?.options?.detail) {
+    doTraverse(uiSchema.options.detail, pre, uiSchema, context);
   }
   // TODO other containments like categorization
+  return context;
 };
 
 export const getUISchemaPath = (
@@ -90,3 +134,28 @@ export const getUISchemaPath = (
   // TODO should be done in a cleaner way
   return `/${path.join('/')}`;
 };
+
+/**
+ * Returns the closes element whose detail contains the given element
+ */
+export const getDetailContainer = (
+  element: LinkedUISchemaElement
+): LinkedUISchemaElement | undefined => {
+  const parentIsDetail = (el: LinkedUISchemaElement) =>
+    el.parent?.options?.detail === el;
+  return getHierarchy(element).find(parentIsDetail)?.parent;
+};
+
+/**
+ * Indicates whether the given ui schema element is a control or contains controls
+ */
+export const containsControls = (element: LinkedUISchemaElement): boolean =>
+  traverse(
+    element,
+    (el, _parent, acc) => {
+      if (isLinkedControl(el)) {
+        acc.containsControls = true;
+      }
+    },
+    { containsControls: false }
+  ).containsControls;

--- a/src/core/renderers/DroppableArrayControl.tsx
+++ b/src/core/renderers/DroppableArrayControl.tsx
@@ -27,7 +27,7 @@ import {
   NewUISchemaElement,
 } from '../dnd';
 import { Actions } from '../model';
-import { containsControls, LinkedControl } from '../model/uischema';
+import { containsControls, EditorControl } from '../model/uischema';
 import { DroppableControlRegistration } from './DroppableControl';
 
 interface StyleProps {
@@ -43,7 +43,7 @@ const useStyles = makeStyles({
 });
 
 interface DroppableArrayControlProps extends ArrayControlProps {
-  uischema: LinkedControl;
+  uischema: EditorControl;
 }
 const DroppableArrayControl: React.FC<DroppableArrayControlProps> = ({
   uischema,

--- a/src/core/renderers/DroppableArrayControl.tsx
+++ b/src/core/renderers/DroppableArrayControl.tsx
@@ -1,0 +1,116 @@
+/**
+ * ---------------------------------------------------------------------
+ * Copyright (c) 2020 EclipseSource Munich
+ * Licensed under MIT
+ * https://github.com/eclipsesource/jsonforms-editor/blob/master/LICENSE
+ * ---------------------------------------------------------------------
+ */
+
+import {
+  ArrayControlProps,
+  isObjectArrayControl,
+  rankWith,
+} from '@jsonforms/core';
+import {
+  JsonFormsDispatch,
+  withJsonFormsArrayControlProps,
+} from '@jsonforms/react';
+import { makeStyles, Typography } from '@material-ui/core';
+import React, { useMemo } from 'react';
+import { useDrop } from 'react-dnd';
+
+import { useDispatch } from '../context';
+import {
+  canDropIntoScope,
+  MOVE_UI_SCHEMA_ELEMENT,
+  NEW_UI_SCHEMA_ELEMENT,
+  NewUISchemaElement,
+} from '../dnd';
+import { Actions } from '../model';
+import { containsControls, LinkedControl } from '../model/uischema';
+import { DroppableControlRegistration } from './DroppableControl';
+
+interface StyleProps {
+  isOver: boolean;
+}
+
+const useStyles = makeStyles({
+  root: ({ isOver }: StyleProps) => ({
+    padding: 10,
+    fontSize: isOver ? '1.1em' : '1em',
+    border: isOver ? '1px solid #D3D3D3' : 'none',
+  }),
+});
+
+interface DroppableArrayControlProps extends ArrayControlProps {
+  uischema: LinkedControl;
+}
+const DroppableArrayControl: React.FC<DroppableArrayControlProps> = ({
+  uischema,
+  schema,
+  path,
+  renderers,
+  cells,
+}) => {
+  const dispatch = useDispatch();
+  const [{ isOver, uiSchemaElement }, drop] = useDrop({
+    accept: [NEW_UI_SCHEMA_ELEMENT, MOVE_UI_SCHEMA_ELEMENT],
+    canDrop: (item): boolean => {
+      switch (item.type) {
+        case NEW_UI_SCHEMA_ELEMENT:
+          return canDropIntoScope(item as NewUISchemaElement, uischema);
+        case MOVE_UI_SCHEMA_ELEMENT:
+          // move as a new detail is only allowed when there are no controls
+          return !containsControls(uiSchemaElement);
+      }
+      // fallback
+      return false;
+    },
+    collect: (mon) => ({
+      isOver: !!mon.isOver() && mon.canDrop(),
+      uiSchemaElement: mon.getItem()?.uiSchemaElement,
+    }),
+    drop: (item): void => {
+      switch (item.type) {
+        case NEW_UI_SCHEMA_ELEMENT:
+          dispatch(Actions.addDetail(uischema.uuid, uiSchemaElement));
+          break;
+        case MOVE_UI_SCHEMA_ELEMENT:
+          dispatch(Actions.moveUiSchemaElement(uiSchemaElement, uischema, 0));
+          break;
+      }
+    },
+  });
+  const classes = useStyles({ isOver });
+
+  // DroppableControl removed itself before dispatching to us, we need
+  // to re-add it for our children
+  const renderersToUse = useMemo(() => {
+    return renderers && [...renderers, DroppableControlRegistration];
+  }, [renderers]);
+
+  if (!uischema.options?.detail) {
+    return (
+      <Typography ref={drop} className={classes.root}>
+        Default array layout. Drag and drop an item here to customize array
+        layout.
+      </Typography>
+    );
+  }
+  return (
+    <JsonFormsDispatch
+      schema={schema}
+      uischema={uischema.options.detail}
+      path={path}
+      renderers={renderersToUse}
+      cells={cells}
+    />
+  );
+};
+
+export const DroppableArrayControlRegistration = {
+  tester: rankWith(900, isObjectArrayControl), // less than DroppableControl
+  renderer: withJsonFormsArrayControlProps(
+    DroppableArrayControl as React.FC<ArrayControlProps>
+  ),
+};

--- a/src/core/renderers/DroppableControl.tsx
+++ b/src/core/renderers/DroppableControl.tsx
@@ -11,10 +11,10 @@ import { ResolvedJsonFormsDispatch } from '@jsonforms/react';
 import React from 'react';
 
 import { EditorElement } from '../../editor/components/EditorElement';
-import { LinkedControl } from '../model/uischema';
+import { EditorControl } from '../model/uischema';
 
 interface DroppableControlProps extends ControlProps {
-  uischema: LinkedControl;
+  uischema: EditorControl;
 }
 const DroppableControl: React.FC<DroppableControlProps> = ({
   uischema,

--- a/src/core/renderers/DroppableControl.tsx
+++ b/src/core/renderers/DroppableControl.tsx
@@ -11,8 +11,11 @@ import { ResolvedJsonFormsDispatch } from '@jsonforms/react';
 import React from 'react';
 
 import { EditorElement } from '../../editor/components/EditorElement';
+import { LinkedControl } from '../model/uischema';
 
-interface DroppableControlProps extends ControlProps {}
+interface DroppableControlProps extends ControlProps {
+  uischema: LinkedControl;
+}
 const DroppableControl: React.FC<DroppableControlProps> = ({
   uischema,
   schema,

--- a/src/core/renderers/DroppableLayout.tsx
+++ b/src/core/renderers/DroppableLayout.tsx
@@ -33,9 +33,9 @@ import {
 } from '../dnd';
 import { Actions } from '../model';
 import {
+  EditorLayout,
+  EditorUISchemaElement,
   getUISchemaPath,
-  LinkedLayout,
-  LinkedUISchemaElement,
 } from '../model/uischema';
 import { isPathError } from '../util/clone';
 
@@ -58,7 +58,7 @@ const useLayoutStyles = makeStyles((theme) => ({
 
 interface DroppableLayoutProps {
   schema: JsonSchema;
-  layout: LinkedLayout;
+  layout: EditorLayout;
   path: string;
   direction: 'row' | 'column';
   renderers?: JsonFormsRendererRegistryEntry[];
@@ -102,7 +102,7 @@ export const DroppableLayoutContent: React.FC<DroppableLayoutProps> = ({
 };
 
 const renderLayoutElementsWithDrops = (
-  layout: LinkedLayout,
+  layout: EditorLayout,
   schema: JsonSchema,
   path: string,
   classes: Record<'dropPointGridItem' | 'jsonformsGridItem', string>,
@@ -150,7 +150,7 @@ const renderLayoutElementsWithDrops = (
 };
 
 interface DropPointProps {
-  layout: LinkedLayout;
+  layout: EditorLayout;
   index: number;
 }
 
@@ -225,7 +225,7 @@ const DropPoint: React.FC<DropPointProps> = ({ layout, index }) => {
   );
 };
 
-const getDataPath = (uischema: LinkedUISchemaElement): string => {
+const getDataPath = (uischema: EditorUISchemaElement): string => {
   const path = getUISchemaPath(uischema);
   if (isPathError(path)) {
     console.error('Could not calculate data-cy path for DropPoint', path);
@@ -239,7 +239,7 @@ const createRendererInDirection = (direction: 'row' | 'column') => ({
   path,
   ...props
 }: LayoutProps) => {
-  const layout = uischema as LinkedLayout;
+  const layout = uischema as EditorLayout;
   return (
     <DroppableLayout
       {...props}

--- a/src/core/util/clone.ts
+++ b/src/core/util/clone.ts
@@ -8,7 +8,7 @@
 import { cloneDeep, get } from 'lodash';
 
 import { SchemaElement } from '../model';
-import { LinkedUISchemaElement } from '../model/uischema';
+import { EditorUISchemaElement } from '../model/uischema';
 import { Parentable } from './tree';
 
 interface CalculatePathError {
@@ -250,7 +250,7 @@ const doGetFromPath = (root: any, path: Array<string>): any => {
 };
 
 export const linkElements = (
-  uiSchemaElement: LinkedUISchemaElement,
+  uiSchemaElement: EditorUISchemaElement,
   schemaElement: SchemaElement
 ): boolean => {
   if (!uiSchemaElement.uuid) {
@@ -258,8 +258,8 @@ export const linkElements = (
     return false;
   }
 
-  (schemaElement.linkedUiSchemaElements =
-    schemaElement.linkedUiSchemaElements || new Set()).add(
+  (schemaElement.linkedUISchemaElements =
+    schemaElement.linkedUISchemaElements || new Set()).add(
     uiSchemaElement.uuid
   );
 

--- a/src/core/util/generators/uiSchema.ts
+++ b/src/core/util/generators/uiSchema.ts
@@ -9,21 +9,21 @@ import { ControlElement, Layout } from '@jsonforms/core';
 import { v4 as uuid } from 'uuid';
 
 import { getScope, SchemaElement } from '../../model';
-import { LinkedUISchemaElement } from '../../model/uischema';
+import { EditorUISchemaElement } from '../../model/uischema';
 export const createControl = (
   schemaElement: SchemaElement
-): ControlElement & LinkedUISchemaElement => {
+): ControlElement & EditorUISchemaElement => {
   return {
     type: 'Control',
     scope: `#${getScope(schemaElement)}`,
     uuid: uuid(),
-  } as ControlElement & LinkedUISchemaElement;
+  } as ControlElement & EditorUISchemaElement;
 };
 
-export const createLayout = (type: string): Layout & LinkedUISchemaElement => {
+export const createLayout = (type: string): Layout & EditorUISchemaElement => {
   return {
     type: type,
     elements: [],
     uuid: uuid(),
-  } as Layout & LinkedUISchemaElement;
+  } as Layout & EditorUISchemaElement;
 };

--- a/src/core/util/generators/uiSchema.ts
+++ b/src/core/util/generators/uiSchema.ts
@@ -8,14 +8,14 @@
 import { ControlElement, Layout } from '@jsonforms/core';
 import { v4 as uuid } from 'uuid';
 
-import { getPath, SchemaElement } from '../../model';
+import { getScope, SchemaElement } from '../../model';
 import { LinkedUISchemaElement } from '../../model/uischema';
 export const createControl = (
   schemaElement: SchemaElement
 ): ControlElement & LinkedUISchemaElement => {
   return {
     type: 'Control',
-    scope: `#${getPath(schemaElement)}`,
+    scope: `#${getScope(schemaElement)}`,
     uuid: uuid(),
   } as ControlElement & LinkedUISchemaElement;
 };

--- a/src/core/util/hooks.ts
+++ b/src/core/util/hooks.ts
@@ -9,12 +9,12 @@ import { useEffect, useRef, useState } from 'react';
 
 import { useSchema, useUiSchema } from '../context';
 import { buildJsonSchema, SchemaElement } from '../model';
-import { buildUiSchema, LinkedUISchemaElement } from '../model/uischema';
+import { buildUiSchema, EditorUISchemaElement } from '../model/uischema';
 
 const doBuildJsonSchema = (schema: SchemaElement | undefined) =>
   schema ? buildJsonSchema(schema) : schema;
 
-const doBuildUiSchema = (uiSchema: LinkedUISchemaElement | undefined) =>
+const doBuildUiSchema = (uiSchema: EditorUISchemaElement | undefined) =>
   uiSchema ? buildUiSchema(uiSchema) : undefined;
 
 /**

--- a/src/core/util/tree.ts
+++ b/src/core/util/tree.ts
@@ -8,3 +8,16 @@
 export interface Parentable<T> {
   parent?: T;
 }
+
+export interface Identifiable {
+  uuid: string;
+}
+
+export interface TreeElement<T> extends Parentable<T>, Identifiable {}
+
+/**
+ * Returns an array starting with the current element followed by its parents
+ */
+export const getHierarchy = <T extends Parentable<T>>(
+  element: T | undefined
+): T[] => (!element ? [] : [element, ...getHierarchy(element.parent)]);

--- a/src/editor/components/Editor.tsx
+++ b/src/editor/components/Editor.tsx
@@ -14,6 +14,7 @@ import { Grid, makeStyles } from '@material-ui/core';
 import React from 'react';
 
 import { useUiSchema } from '../../core/context';
+import { DroppableArrayControlRegistration } from '../../core/renderers/DroppableArrayControl';
 import { DroppableControlRegistration } from '../../core/renderers/DroppableControl';
 import {
   DroppableHorizontalLayoutRegistration,
@@ -21,6 +22,14 @@ import {
 } from '../../core/renderers/DroppableLayout';
 import { useExportSchema } from '../../core/util/hooks';
 import { EmptyEditor } from './EmptyEditor';
+
+const renderers = [
+  ...materialRenderers,
+  DroppableHorizontalLayoutRegistration,
+  DroppableVerticalLayoutRegistration,
+  DroppableControlRegistration,
+  DroppableArrayControlRegistration,
+];
 
 const useStyles = makeStyles(() => ({
   jsonformsGridContainer: {
@@ -39,12 +48,7 @@ export const Editor: React.FC = () => {
         data={{}}
         schema={schema}
         uischema={uiSchema}
-        renderers={[
-          ...materialRenderers,
-          DroppableHorizontalLayoutRegistration,
-          DroppableVerticalLayoutRegistration,
-          DroppableControlRegistration,
-        ]}
+        renderers={renderers}
         cells={materialCells}
       />
     </Grid>

--- a/src/editor/components/EditorElement.tsx
+++ b/src/editor/components/EditorElement.tsx
@@ -17,14 +17,14 @@ import { DndItems } from '../../core/dnd';
 import { SchemaIcon, UISchemaIcon } from '../../core/icons';
 import { Actions } from '../../core/model';
 import {
+  EditorUISchemaElement,
   getUISchemaPath,
   hasChildren,
-  LinkedUISchemaElement,
 } from '../../core/model/uischema';
 import { tryFindByUUID } from '../../core/util/clone';
 
 export interface EditorElementProps {
-  wrappedElement: LinkedUISchemaElement;
+  wrappedElement: EditorUISchemaElement;
   onHoverCallback?: (isHover: boolean) => void;
 }
 

--- a/src/editor/components/EditorElement.tsx
+++ b/src/editor/components/EditorElement.tsx
@@ -14,7 +14,7 @@ import { useDrag } from 'react-dnd';
 import { OkCancelDialog } from '../../core/components/OkCancelDialog';
 import { useDispatch, useSchema, useSelection } from '../../core/context';
 import { DndItems } from '../../core/dnd';
-import { UISchemaIcon } from '../../core/icons';
+import { SchemaIcon, UISchemaIcon } from '../../core/icons';
 import { Actions } from '../../core/model';
 import {
   getUISchemaPath,
@@ -87,13 +87,9 @@ export const EditorElement: React.FC<EditorElementProps> = ({
       } ${isSelected ? classes.elementSelected : ''}`}
       ref={drag}
       onClick={(event) => {
-        if (wrappedElement.uuid) {
-          event.stopPropagation();
-          const newSelection = { uuid: wrappedElement.uuid };
-          setSelection(newSelection);
-        } else {
-          console.error('Found element without UUID', wrappedElement);
-        }
+        event.stopPropagation();
+        const newSelection = { uuid: wrappedElement.uuid };
+        setSelection(newSelection);
       }}
     >
       <Grid
@@ -105,7 +101,11 @@ export const EditorElement: React.FC<EditorElementProps> = ({
         data-cy={`editorElement-${uiPath}-header`}
       >
         <Grid item container alignItems='center' xs>
-          <UISchemaIcon type={wrappedElement.type} />
+          {elementSchema ? (
+            <SchemaIcon type={elementSchema.type} />
+          ) : (
+            <UISchemaIcon type={wrappedElement.type} />
+          )}
         </Grid>
         <Grid
           item

--- a/src/palette-panel/components/SchemaTree.tsx
+++ b/src/palette-panel/components/SchemaTree.tsx
@@ -10,11 +10,13 @@ import React from 'react';
 import { useDrag } from 'react-dnd';
 
 import { DndItems } from '../../core/dnd';
-import { getIconForSchemaType } from '../../core/icons';
+import { SchemaIcon } from '../../core/icons';
 import {
   getChildren,
   getLabel,
   getPath,
+  isArrayElement,
+  isObjectElement,
   SchemaElement,
 } from '../../core/model/schema';
 import { LinkedUISchemaElement } from '../../core/model/uischema';
@@ -41,15 +43,29 @@ const SchemaTreeItem: React.FC<SchemaTreeItemProps> = ({ schemaElement }) => {
         key={schemaElementPath}
         nodeId={schemaElementPath}
         label={getLabel(schemaElement)}
-        icon={React.createElement(getIconForSchemaType(schemaElement.type), {})}
+        icon={<SchemaIcon type={schemaElement.type} />}
         isDragging={isDragging}
       >
-        {getChildren(schemaElement).map((child) => (
+        {getChildrenToRender(schemaElement).map((child) => (
           <SchemaTreeItem schemaElement={child} key={getPath(child)} />
         ))}
       </StyledTreeItem>
     </div>
   );
+};
+
+const getChildrenToRender = (schemaElement: SchemaElement) => {
+  return getChildren(schemaElement).flatMap((child) => {
+    // if the child is the only item of an array, use its children instead
+    if (
+      isObjectElement(child) &&
+      isArrayElement(child.parent) &&
+      child.parent.items === child
+    ) {
+      return getChildren(child);
+    }
+    return [child];
+  });
 };
 
 export const SchemaTreeView: React.FC<{

--- a/src/palette-panel/components/SchemaTree.tsx
+++ b/src/palette-panel/components/SchemaTree.tsx
@@ -19,7 +19,7 @@ import {
   isObjectElement,
   SchemaElement,
 } from '../../core/model/schema';
-import { LinkedUISchemaElement } from '../../core/model/uischema';
+import { EditorUISchemaElement } from '../../core/model/uischema';
 import { createControl } from '../../core/util/generators/uiSchema';
 import { StyledTreeItem, StyledTreeView } from './Tree';
 
@@ -28,7 +28,7 @@ interface SchemaTreeItemProps {
 }
 
 const SchemaTreeItem: React.FC<SchemaTreeItemProps> = ({ schemaElement }) => {
-  const uiSchemaElement: LinkedUISchemaElement = createControl(schemaElement);
+  const uiSchemaElement: EditorUISchemaElement = createControl(schemaElement);
 
   const [{ isDragging }, drag] = useDrag({
     item: DndItems.newUISchemaElement(uiSchemaElement, schemaElement),

--- a/src/palette-panel/components/UIElementsTree.tsx
+++ b/src/palette-panel/components/UIElementsTree.tsx
@@ -5,18 +5,18 @@
  * https://github.com/eclipsesource/jsonforms-editor/blob/master/LICENSE
  * ---------------------------------------------------------------------
  */
-import { UISchemaElement } from '@jsonforms/core';
 import Typography from '@material-ui/core/Typography';
 import React from 'react';
 import { useDrag } from 'react-dnd';
 
 import { DndItems } from '../../core/dnd';
 import { HorizontalIcon, VerticalIcon } from '../../core/icons';
+import { LinkedUISchemaElement } from '../../core/model/uischema';
 import { createLayout } from '../../core/util/generators/uiSchema';
 import { StyledTreeItem, StyledTreeView } from './Tree';
 
 interface UiSchemaTreeItemProps {
-  uiSchemaElement: UISchemaElement;
+  uiSchemaElement: LinkedUISchemaElement;
   label: string;
   icon?: React.ReactNode;
 }

--- a/src/palette-panel/components/UIElementsTree.tsx
+++ b/src/palette-panel/components/UIElementsTree.tsx
@@ -11,12 +11,12 @@ import { useDrag } from 'react-dnd';
 
 import { DndItems } from '../../core/dnd';
 import { HorizontalIcon, VerticalIcon } from '../../core/icons';
-import { LinkedUISchemaElement } from '../../core/model/uischema';
+import { EditorUISchemaElement } from '../../core/model/uischema';
 import { createLayout } from '../../core/util/generators/uiSchema';
 import { StyledTreeItem, StyledTreeView } from './Tree';
 
 interface UiSchemaTreeItemProps {
-  uiSchemaElement: LinkedUISchemaElement;
+  uiSchemaElement: EditorUISchemaElement;
   label: string;
   icon?: React.ReactNode;
 }

--- a/src/properties/components/Properties.tsx
+++ b/src/properties/components/Properties.tsx
@@ -20,13 +20,13 @@ import {
   useUiSchema,
 } from '../../core/context';
 import { Actions, SchemaElement } from '../../core/model';
-import { LinkedUISchemaElement } from '../../core/model/uischema';
+import { EditorUISchemaElement } from '../../core/model/uischema';
 import { tryFindByUUID } from '../../core/util/clone';
 import { ExamplePropertiesService } from '../propertiesService';
 
 const propertiesService = new ExamplePropertiesService();
 const getProperties = (
-  uiElement: LinkedUISchemaElement | undefined,
+  uiElement: EditorUISchemaElement | undefined,
   schema: SchemaElement | undefined
 ) => {
   if (!uiElement || !schema) {
@@ -46,12 +46,12 @@ export const Properties = () => {
   const schema = useSchema();
   const dispatch = useDispatch();
 
-  const uiElement: LinkedUISchemaElement = useMemo(
+  const uiElement: EditorUISchemaElement = useMemo(
     () => tryFindByUUID(uiSchema, selection?.uuid),
     [selection, uiSchema]
   );
   const canSetUISchemaOptions = (
-    uiElement: LinkedUISchemaElement | undefined,
+    uiElement: EditorUISchemaElement | undefined,
     updatedProperties: any
   ): boolean =>
     !!uiElement &&

--- a/src/properties/propertiesService.ts
+++ b/src/properties/propertiesService.ts
@@ -8,7 +8,7 @@
 import { JsonSchema, UISchemaElement } from '@jsonforms/core';
 
 import { SchemaElement } from '../core/model';
-import { LinkedUISchemaElement } from '../core/model/uischema';
+import { EditorUISchemaElement } from '../core/model/uischema';
 
 export interface PropertiesService {
   getProperties(
@@ -24,7 +24,7 @@ interface PropertySchemas {
 
 export class ExamplePropertiesService implements PropertiesService {
   getProperties = (
-    uiElement: LinkedUISchemaElement,
+    uiElement: EditorUISchemaElement,
     schemaElement: SchemaElement | undefined
   ): PropertySchemas | undefined => {
     if (


### PR DESCRIPTION
Adds `DroppableArrayControl` which allows to customize an array control's
detail. As such details are differently scoped to the rest of the ui
schema only certain controls can be created there and no controls can be
moved in and out. Existing reducers were adapted to respect these new
restrictions.

Also:
* Adjust LinkedUISchemaElement type to enforce uuids
* Normalize mappings in SchemaElements
* Adapt editor control icons to indicate their type

Renames `LinkedUISchemaElement`, `LinkedLayout` and `LinkedControl` to
`EditorSchemaElement`, `EditorLayout` and `EditorControl`. Also renames
variables and functions where applicable