### PR TITLE
Adjust JsonEditorDialog CSS

### DIFF
--- a/src/text-editor/JsonEditorDialog.tsx
+++ b/src/text-editor/JsonEditorDialog.tsx
@@ -30,8 +30,12 @@ const useStyles = makeStyles((theme: Theme) =>
       marginLeft: theme.spacing(2),
       flex: 1,
     },
+    dialogPaper: {
+      height: '100%', // 'MonacoEditor' uses height to grow
+      minHeight: '95vh',
+      maxHeight: '95vh',
+    },
     dialogContent: {
-      height: '90vh',
       overflow: 'hidden',
       marginTop: theme.spacing(2),
       flex: 1,
@@ -69,6 +73,7 @@ export const JsonEditorDialog: React.FC<JsonEditorDialogProps> = ({
       open={open}
       onClose={onCancel}
       TransitionComponent={Transition}
+      classes={{ paper: classes.dialogPaper }}
       maxWidth='lg'
       fullWidth
     >


### PR DESCRIPTION
Control the dialog height via CSS on the root paper Material UI uses to
render its dialogs instead of using the DialogContent. This fixes an
issue where the dialog wouldn't be rendered with its intended height in
Firefox. To grow the MonacoEditor component an additional height
property must be set as react-monaco-editor uses a plain height approach
internally.