### PR TITLE
Validate JSON Schema in Monaco Editor

### DIFF
--- a/cypress/fixtures/invalidSchema.json
+++ b/cypress/fixtures/invalidSchema.json
@@ -1,0 +1,4 @@
+{
+  "type": "object",
+  "properties": "invalidProperty"
+}

--- a/cypress/integration/editSchemas.spec.js
+++ b/cypress/integration/editSchemas.spec.js
@@ -10,19 +10,29 @@ describe('Edit schemas', () => {
     cy.fixture('simpleSchema').then((simpleSchema) => {
       this.simpleSchema = simpleSchema;
     });
+    cy.fixture('invalidSchema').then((invalidSchema) => {
+      this.invalidSchema = invalidSchema;
+    });
     cy.fixture('simpleUiSchema').then((simpleUiSchema) => {
       this.simpleUiSchema = simpleUiSchema;
     });
     cy.visit('/');
   });
 
+  const cyReplaceTextInFocus = (jsonObject) => {
+    cy.focused()
+      .type('{ctrl}a')
+      .type('{del}')
+      .type(JSON.stringify(jsonObject), {
+        parseSpecialCharSequences: false,
+      });
+  };
+
   const editSchema = (schema, tabSelector) => {
     cy.get(`[data-cy="${tabSelector}"]`).click();
     cy.get('[data-cy="edit-schema"]').click();
 
-    cy.focused().type('{ctrl}a').type('{del}').type(JSON.stringify(schema), {
-      parseSpecialCharSequences: false,
-    });
+    cyReplaceTextInFocus(schema);
     cy.get('[data-cy="apply"]').click();
 
     cy.get('[data-cy="schema-text"]').should(
@@ -38,12 +48,7 @@ describe('Edit schemas', () => {
       .invoke('text')
       .then((originalText) => {
         cy.get('[data-cy="edit-schema"]').click();
-        cy.focused()
-          .type('{ctrl}a')
-          .type('{del}')
-          .type(JSON.stringify(schema), {
-            parseSpecialCharSequences: false,
-          });
+        cyReplaceTextInFocus(schema);
         cy.get('[data-cy="cancel"]').click();
 
         cy.get('[data-cy="schema-text"]').should('have.text', originalText);
@@ -57,12 +62,7 @@ describe('Edit schemas', () => {
       .invoke('text')
       .then((originalText) => {
         cy.get('[data-cy="edit-schema"]').click();
-        cy.focused()
-          .type('{ctrl}a')
-          .type('{del}')
-          .type(JSON.stringify(schema), {
-            parseSpecialCharSequences: false,
-          });
+        cyReplaceTextInFocus(schema);
         cy.focused().type('{esc}');
 
         cy.get('[data-cy="schema-text"]').should('have.text', originalText);
@@ -79,6 +79,30 @@ describe('Edit schemas', () => {
 
   it('Escape Edit JSON Schema', function () {
     escapeEditSchema(this.simpleSchema, 'schema-tab');
+  });
+
+  it('Validate invalid JSON Schema', function () {
+    cy.get(`[data-cy="schema-tab"]`).click();
+
+    cy.get('[data-cy="schema-text"]')
+      .invoke('text')
+      .then((originalText) => {
+        cy.get('[data-cy="edit-schema"]').click();
+        cyReplaceTextInFocus(this.invalidSchema);
+        cy.get('.squiggly-warning').should('exist');
+      });
+  });
+
+  it('Validate valid JSON Schema', function () {
+    cy.get(`[data-cy="schema-tab"]`).click();
+
+    cy.get('[data-cy="schema-text"]')
+      .invoke('text')
+      .then((originalText) => {
+        cy.get('[data-cy="edit-schema"]').click();
+        cyReplaceTextInFocus(this.simpleSchema);
+        cy.get('.squiggly-warning').should('not.exist');
+      });
   });
 
   it('Edit UI Schema', function () {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14658,9 +14658,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "3.7.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
-      "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw=="
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.6.tgz",
+      "integrity": "sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw=="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "react-scripts": "3.4.1",
     "react-spring": "^8.0.27",
     "redux": "^4.0.5",
-    "typescript": "~3.7.2",
+    "typescript": "^3.9.6",
     "uuid": "^8.1.0"
   },
   "scripts": {

--- a/src/core/jsonschema/index.ts
+++ b/src/core/jsonschema/index.ts
@@ -1,0 +1,18 @@
+/**
+ * ---------------------------------------------------------------------
+ * Copyright (c) 2020 EclipseSource Munich
+ * Licensed under MIT
+ * https://github.com/eclipsesource/jsonforms-editor/blob/master/LICENSE
+ * ---------------------------------------------------------------------
+ */
+import schema from './specification/schema.json';
+
+interface SchemaInformation {
+  uri: string;
+  schema: any;
+}
+
+export const jsonSchemaDraft7 = {
+  uri: 'http://json-schema.org/draft-07/schema',
+  schema: schema,
+};

--- a/src/core/jsonschema/specification/schema.json
+++ b/src/core/jsonschema/specification/schema.json
@@ -1,0 +1,166 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://json-schema.org/draft-07/schema#",
+  "title": "Core schema meta-schema",
+  "definitions": {
+    "schemaArray": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#" }
+    },
+    "nonNegativeInteger": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "nonNegativeIntegerDefault0": {
+      "allOf": [
+        { "$ref": "#/definitions/nonNegativeInteger" },
+        { "default": 0 }
+      ]
+    },
+    "simpleTypes": {
+      "enum": [
+        "array",
+        "boolean",
+        "integer",
+        "null",
+        "number",
+        "object",
+        "string"
+      ]
+    },
+    "stringArray": {
+      "type": "array",
+      "items": { "type": "string" },
+      "uniqueItems": true,
+      "default": []
+    }
+  },
+  "type": ["object", "boolean"],
+  "properties": {
+    "$id": {
+      "type": "string",
+      "format": "uri-reference"
+    },
+    "$schema": {
+      "type": "string",
+      "format": "uri"
+    },
+    "$ref": {
+      "type": "string",
+      "format": "uri-reference"
+    },
+    "$comment": {
+      "type": "string"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "default": true,
+    "readOnly": {
+      "type": "boolean",
+      "default": false
+    },
+    "writeOnly": {
+      "type": "boolean",
+      "default": false
+    },
+    "examples": {
+      "type": "array",
+      "items": true
+    },
+    "multipleOf": {
+      "type": "number",
+      "exclusiveMinimum": 0
+    },
+    "maximum": {
+      "type": "number"
+    },
+    "exclusiveMaximum": {
+      "type": "number"
+    },
+    "minimum": {
+      "type": "number"
+    },
+    "exclusiveMinimum": {
+      "type": "number"
+    },
+    "maxLength": { "$ref": "#/definitions/nonNegativeInteger" },
+    "minLength": { "$ref": "#/definitions/nonNegativeIntegerDefault0" },
+    "pattern": {
+      "type": "string",
+      "format": "regex"
+    },
+    "additionalItems": { "$ref": "#" },
+    "items": {
+      "anyOf": [{ "$ref": "#" }, { "$ref": "#/definitions/schemaArray" }],
+      "default": true
+    },
+    "maxItems": { "$ref": "#/definitions/nonNegativeInteger" },
+    "minItems": { "$ref": "#/definitions/nonNegativeIntegerDefault0" },
+    "uniqueItems": {
+      "type": "boolean",
+      "default": false
+    },
+    "contains": { "$ref": "#" },
+    "maxProperties": { "$ref": "#/definitions/nonNegativeInteger" },
+    "minProperties": { "$ref": "#/definitions/nonNegativeIntegerDefault0" },
+    "required": { "$ref": "#/definitions/stringArray" },
+    "additionalProperties": { "$ref": "#" },
+    "definitions": {
+      "type": "object",
+      "additionalProperties": { "$ref": "#" },
+      "default": {}
+    },
+    "properties": {
+      "type": "object",
+      "additionalProperties": { "$ref": "#" },
+      "default": {}
+    },
+    "patternProperties": {
+      "type": "object",
+      "additionalProperties": { "$ref": "#" },
+      "propertyNames": { "format": "regex" },
+      "default": {}
+    },
+    "dependencies": {
+      "type": "object",
+      "additionalProperties": {
+        "anyOf": [{ "$ref": "#" }, { "$ref": "#/definitions/stringArray" }]
+      }
+    },
+    "propertyNames": { "$ref": "#" },
+    "const": true,
+    "enum": {
+      "type": "array",
+      "items": true,
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "type": {
+      "anyOf": [
+        { "$ref": "#/definitions/simpleTypes" },
+        {
+          "type": "array",
+          "items": { "$ref": "#/definitions/simpleTypes" },
+          "minItems": 1,
+          "uniqueItems": true
+        }
+      ]
+    },
+    "format": { "type": "string" },
+    "contentMediaType": { "type": "string" },
+    "contentEncoding": { "type": "string" },
+    "if": { "$ref": "#" },
+    "then": { "$ref": "#" },
+    "else": { "$ref": "#" },
+    "allOf": { "$ref": "#/definitions/schemaArray" },
+    "anyOf": { "$ref": "#/definitions/schemaArray" },
+    "oneOf": { "$ref": "#/definitions/schemaArray" },
+    "not": { "$ref": "#" }
+  },
+  "default": true
+}

--- a/src/palette-panel/components/PalletePanel.tsx
+++ b/src/palette-panel/components/PalletePanel.tsx
@@ -90,6 +90,7 @@ export const PalettePanel = () => {
         <SchemaJson
           title='JSON Schema'
           schema={toText(exportSchema)}
+          type='JSON Schema'
           updateSchema={handleSchemaUpdate}
         />
       </TabContent>
@@ -97,6 +98,7 @@ export const PalettePanel = () => {
         <SchemaJson
           title='UI Schema'
           schema={toText(exportUiSchema)}
+          type='UI Schema'
           updateSchema={handleUiSchemaUpdate}
         />
       </TabContent>

--- a/src/palette-panel/components/SchemaJson.tsx
+++ b/src/palette-panel/components/SchemaJson.tsx
@@ -12,7 +12,7 @@ import React, { useState } from 'react';
 
 import { ErrorDialog } from '../../core/components/ErrorDialog';
 import { copyToClipBoard } from '../../core/util/clipboard';
-import { JsonEditorDialog } from '../../text-editor/JsonEditorDialog';
+import { JsonEditorDialog, TextType } from '../../text-editor';
 
 interface UpdateOk {
   success: true;
@@ -27,12 +27,14 @@ export type UpdateResult = UpdateOk | UpdateFail;
 interface SchemaJsonProps {
   title: string;
   schema: string;
+  type: TextType;
   updateSchema: (schema: any) => UpdateResult;
 }
 
 export const SchemaJson: React.FC<SchemaJsonProps> = ({
   title,
   schema,
+  type,
   updateSchema,
 }) => {
   const [showSchemaEditor, setShowSchemaEditor] = useState<boolean>(false);
@@ -68,6 +70,7 @@ export const SchemaJson: React.FC<SchemaJsonProps> = ({
           open
           title={title}
           initialContent={schema}
+          type={type}
           onCancel={() => setShowSchemaEditor(false)}
           onApply={onApply}
         />

--- a/src/text-editor/components/JsonEditorDialog.tsx
+++ b/src/text-editor/components/JsonEditorDialog.tsx
@@ -14,8 +14,14 @@ import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import Toolbar from '@material-ui/core/Toolbar';
 import { TransitionProps } from '@material-ui/core/transitions';
 import CloseIcon from '@material-ui/icons/Close';
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import MonacoEditor from 'react-monaco-editor';
+
+import {
+  configureJsonSchemaValidation,
+  EditorApi,
+  TextType,
+} from '../jsonSchemaValidation';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -54,6 +60,7 @@ interface JsonEditorDialogProps {
   open: boolean;
   title: string;
   initialContent: any;
+  type: TextType;
   onApply: (newContent: any) => void;
   onCancel: () => void;
 }
@@ -62,11 +69,21 @@ export const JsonEditorDialog: React.FC<JsonEditorDialogProps> = ({
   open,
   title,
   initialContent,
+  type,
   onApply,
   onCancel,
 }) => {
   const classes = useStyles();
   const [content, setContent] = useState(initialContent);
+
+  const configureEditor = useCallback(
+    (editor: EditorApi) => {
+      if (type === 'JSON Schema') {
+        configureJsonSchemaValidation(editor);
+      }
+    },
+    [type]
+  );
 
   return (
     <Dialog
@@ -106,6 +123,7 @@ export const JsonEditorDialog: React.FC<JsonEditorDialogProps> = ({
           value={content}
           onChange={(newContent) => setContent(newContent)}
           editorDidMount={(editor) => editor.focus()}
+          editorWillMount={configureEditor}
         />
       </DialogContent>
     </Dialog>

--- a/src/text-editor/index.ts
+++ b/src/text-editor/index.ts
@@ -1,0 +1,9 @@
+/**
+ * ---------------------------------------------------------------------
+ * Copyright (c) 2020 EclipseSource Munich
+ * Licensed under MIT
+ * https://github.com/eclipsesource/jsonforms-editor/blob/master/LICENSE
+ * ---------------------------------------------------------------------
+ */
+export { JsonEditorDialog } from './components/JsonEditorDialog';
+export type { TextType } from './jsonSchemaValidation';

--- a/src/text-editor/jsonSchemaValidation.ts
+++ b/src/text-editor/jsonSchemaValidation.ts
@@ -1,0 +1,26 @@
+/**
+ * ---------------------------------------------------------------------
+ * Copyright (c) 2020 EclipseSource Munich
+ * Licensed under MIT
+ * https://github.com/eclipsesource/jsonforms-editor/blob/master/LICENSE
+ * ---------------------------------------------------------------------
+ */
+import editorApi from 'monaco-editor/esm/vs/editor/editor.api';
+
+import { jsonSchemaDraft7 } from '../core/jsonschema';
+
+export type EditorApi = typeof editorApi;
+export type TextType = 'JSON' | 'JSON Schema' | 'UI Schema';
+
+/**
+ * Configures the Monaco Editor to validate the input against JSON Schema Draft 7.
+ */
+export const configureJsonSchemaValidation = (editor: EditorApi) => {
+  /** Note that the Monaco Editor only supports JSON Schema Draft 7 itself,
+   * so if we also want to support a later standard we still have to formalize
+   * it in JSON Schema Draft 7*/
+  editor.languages.json.jsonDefaults.setDiagnosticsOptions({
+    validate: true,
+    schemas: [{ ...jsonSchemaDraft7, fileMatch: ['*'] }],
+  });
+};


### PR DESCRIPTION
The JSON Schema Text Editor is now configured to validate againt JSON
Schema Draft 7.

The Monaco Editor supports validating against schemas specified in JSON
Schema Draft 7. We use the available JSON Schema Draft 7 metaschema to
validate the JSON Schema text input. If we want to support a later
draft, e.g. '2019-09' we need to use a metaschema written against Draft
7.

![InvalidType](https://user-images.githubusercontent.com/8998368/86589161-6c826400-bf8d-11ea-8746-d53b2bfd2acc.png)
