### PR TITLE
Allow editing labels of controls in Properties View

### DIFF
--- a/src/properties/propertiesService.ts
+++ b/src/properties/propertiesService.ts
@@ -113,7 +113,11 @@ const ruleDecorator: PropertiesSchemasDecorators = {
 
 const labelDecorator: PropertiesSchemasDecorators = {
   decorate: (schemas: PropertySchemas, uiElement: EditorUISchemaElement) => {
-    if (uiElement?.type === 'Group') {
+    if (
+      ['Group', 'Control', 'Categorization', 'Category'].includes(
+        uiElement?.type
+      )
+    ) {
       if (!schemas.schema.properties) {
         schemas.schema.properties = {};
       }


### PR DESCRIPTION
Set and modify labels via the  Properties view.
Fixes #68 

**_Only commit 32e5397 is relevant to this PR and it should be merged after https://github.com/eclipsesource/jsonforms-editor/pull/77._**

![control-labels](https://user-images.githubusercontent.com/6464495/87434959-658dce00-c5eb-11ea-8de0-ee8243e11436.gif)

