### PR TITLE
Reuse DroppableElement in layouts and use UUIDs in actions

### DIFF
--- a/jsonforms-editor/src/core/dnd/types.ts
+++ b/jsonforms-editor/src/core/dnd/types.ts
@@ -12,6 +12,7 @@ import {
   EditorUISchemaElement,
   getDetailContainer,
 } from '../model/uischema';
+import { tryFindByUUID } from '../util/schemasUtil';
 import { getHierarchy } from '../util/tree';
 
 export const NEW_UI_SCHEMA_ELEMENT: 'newUiSchemaElement' = 'newUiSchemaElement';
@@ -23,16 +24,16 @@ export type DndType = NewUISchemaElement | MoveUISchemaElement;
 export interface NewUISchemaElement {
   type: 'newUiSchemaElement';
   uiSchemaElement: EditorUISchemaElement;
-  schema?: SchemaElement;
+  schemaUUID?: string;
 }
 
 const newUISchemaElement = (
   uiSchemaElement: EditorUISchemaElement,
-  schema?: SchemaElement
+  schemaUUID?: string
 ) => ({
   type: NEW_UI_SCHEMA_ELEMENT,
   uiSchemaElement,
-  schema,
+  schemaUUID,
 });
 
 export interface MoveUISchemaElement {
@@ -54,11 +55,12 @@ export const DndItems = { newUISchemaElement, moveUISchemaElement };
 
 export const canDropIntoLayout = (
   item: NewUISchemaElement,
+  rootSchema: SchemaElement | undefined,
   layout: EditorUISchemaElement
 ) => {
   // check scope changes
   const detailContainer = getDetailContainer(layout);
-  return canDropIntoScope(item, detailContainer);
+  return canDropIntoScope(item, rootSchema, detailContainer);
 };
 
 /**
@@ -72,9 +74,10 @@ export const canDropIntoLayout = (
  */
 export const canDropIntoScope = (
   item: NewUISchemaElement,
+  rootSchema: SchemaElement | undefined,
   scopeUISchemaElement: EditorUISchemaElement | undefined
 ) => {
-  const controlObject = item.schema;
+  const controlObject = tryFindByUUID(rootSchema, item.schemaUUID);
   if (controlObject) {
     const scopeSchemaElement = getScopeChangingContainer(controlObject);
     if (!scopesMatch(scopeSchemaElement, scopeUISchemaElement)) {

--- a/jsonforms-editor/src/core/model/actions.ts
+++ b/jsonforms-editor/src/core/model/actions.ts
@@ -59,34 +59,34 @@ export interface SetSchemasAction {
 export interface AddScopedElementToLayout {
   type: 'jsonforms-editor/ADD_SCOPED_ELEMENT_TO_LAYOUT';
   uiSchemaElement: EditorUISchemaElement;
-  layout: EditorLayout;
-  schema: SchemaElement;
+  layoutUUID: string;
+  schemaUUID: string;
   index: number;
 }
 
 export interface AddUnscopedElementToLayout {
   type: 'jsonforms-editor/ADD_UNSCOPED_ELEMENT_TO_LAYOUT';
   uiSchemaElement: EditorUISchemaElement;
-  layout: EditorLayout;
+  layoutUUID: string;
   index: number;
 }
 
 export interface MoveUiSchemaElement {
   type: 'jsonforms-editor/MOVE_UISCHEMA_ELEMENT';
-  uiSchemaElement: EditorUISchemaElement;
-  newContainer: EditorUISchemaElement;
+  elementUUID: string;
+  newContainerUUID: string;
   index: number;
-  schema?: SchemaElement;
+  schemaUUID?: string;
 }
 
 export interface RemoveUiSchemaElement {
   type: 'jsonforms-editor/REMOVE_UISCHEMA_ELEMENT';
-  uiSchemaElement: EditorUISchemaElement;
+  elementUUID: string;
 }
 
 export interface UpdateUiSchemaElement {
   type: 'jsonforms-editor/UPDATE_UISCHEMA_ELEMENT';
-  uiSchemaElement: EditorUISchemaElement;
+  elementUUID: string;
   changedProperties: { [key: string]: any };
 }
 
@@ -114,50 +114,50 @@ const setSchemas = (schema: any, uiSchema: any) => ({
 
 const addScopedElementToLayout = (
   uiSchemaElement: EditorUISchemaElement,
-  layout: EditorLayout,
+  layoutUUID: string,
   index: number,
-  schema: any
+  schemaUUID: string
 ) => ({
   type: ADD_SCOPED_ELEMENT_TO_LAYOUT,
   uiSchemaElement,
-  layout,
+  layoutUUID,
   index,
-  schema,
+  schemaUUID,
 });
 
 const addUnscopedElementToLayout = (
   uiSchemaElement: EditorUISchemaElement,
-  layout: EditorLayout,
+  layoutUUID: string,
   index: number
 ) => ({
   type: ADD_UNSCOPED_ELEMENT_TO_LAYOUT,
   uiSchemaElement,
-  layout,
+  layoutUUID,
   index,
 });
 
 const moveUiSchemaElement = (
-  uiSchemaElement: EditorUISchemaElement,
-  newContainer: EditorUISchemaElement,
+  elementUUID: string,
+  newContainerUUID: string,
   index: number,
-  schema?: SchemaElement
+  schemaUUID?: string
 ) => ({
   type: MOVE_UISCHEMA_ELEMENT,
-  uiSchemaElement,
-  newContainer,
+  elementUUID,
+  newContainerUUID,
   index,
-  schema,
+  schemaUUID,
 });
 
-const removeUiSchemaElement = (uiSchemaElement: EditorUISchemaElement) => ({
+const removeUiSchemaElement = (elementUUID: string) => ({
   type: REMOVE_UISCHEMA_ELEMENT,
-  uiSchemaElement,
+  elementUUID,
 });
 
 const updateUISchemaElement = (
-  uiSchemaElement: EditorUISchemaElement,
+  elementUUID: string,
   changedProperties: { [key: string]: any }
-) => ({ type: UPDATE_UISCHEMA_ELEMENT, uiSchemaElement, changedProperties });
+) => ({ type: UPDATE_UISCHEMA_ELEMENT, elementUUID, changedProperties });
 
 const addDetail = (
   uiSchemaElementId: string,

--- a/jsonforms-editor/src/core/model/reducer.test.ts
+++ b/jsonforms-editor/src/core/model/reducer.test.ts
@@ -216,7 +216,7 @@ describe('REMOVE_UISCHEMA_ELEMENT action', () => {
 
     const brokenControl = (brokenState.uiSchema as EditorLayout).elements[0];
     const removeBrokenElementAction = Actions.removeUiSchemaElement(
-      brokenControl
+      brokenControl.uuid
     );
 
     // REMOVE BROKEN CONTROL

--- a/jsonforms-editor/src/core/model/uischema.ts
+++ b/jsonforms-editor/src/core/model/uischema.ts
@@ -157,7 +157,7 @@ export const getDetailContainer = (
   element: EditorUISchemaElement
 ): EditorUISchemaElement | undefined => {
   const parentIsDetail = (el: EditorUISchemaElement) =>
-    el.parent?.options?.detail && el.parent.options.detail.uuid === el.uuid;
+    el.parent?.options?.detail?.uuid === el.uuid;
 
   return getHierarchy(element).find(parentIsDetail)?.parent;
 };

--- a/jsonforms-editor/src/core/model/uischema.ts
+++ b/jsonforms-editor/src/core/model/uischema.ts
@@ -157,7 +157,8 @@ export const getDetailContainer = (
   element: EditorUISchemaElement
 ): EditorUISchemaElement | undefined => {
   const parentIsDetail = (el: EditorUISchemaElement) =>
-    el.parent?.options?.detail === el;
+    el.parent?.options?.detail && el.parent.options.detail.uuid === el.uuid;
+
   return getHierarchy(element).find(parentIsDetail)?.parent;
 };
 

--- a/jsonforms-editor/src/core/renderers/DroppableArrayControl.tsx
+++ b/jsonforms-editor/src/core/renderers/DroppableArrayControl.tsx
@@ -19,7 +19,7 @@ import { makeStyles, Typography } from '@material-ui/core';
 import React, { useMemo } from 'react';
 import { useDrop } from 'react-dnd';
 
-import { useDispatch } from '../context';
+import { useDispatch, useSchema } from '../context';
 import {
   canDropIntoScope,
   MOVE_UI_SCHEMA_ELEMENT,
@@ -53,12 +53,17 @@ const DroppableArrayControl: React.FC<DroppableArrayControlProps> = ({
   cells,
 }) => {
   const dispatch = useDispatch();
+  const rootSchema = useSchema();
   const [{ isOver, uiSchemaElement }, drop] = useDrop({
     accept: [NEW_UI_SCHEMA_ELEMENT, MOVE_UI_SCHEMA_ELEMENT],
     canDrop: (item): boolean => {
       switch (item.type) {
         case NEW_UI_SCHEMA_ELEMENT:
-          return canDropIntoScope(item as NewUISchemaElement, uischema);
+          return canDropIntoScope(
+            item as NewUISchemaElement,
+            rootSchema,
+            uischema
+          );
         case MOVE_UI_SCHEMA_ELEMENT:
           // move as a new detail is only allowed when there are no controls
           return !containsControls(uiSchemaElement);
@@ -76,7 +81,9 @@ const DroppableArrayControl: React.FC<DroppableArrayControlProps> = ({
           dispatch(Actions.addDetail(uischema.uuid, uiSchemaElement));
           break;
         case MOVE_UI_SCHEMA_ELEMENT:
-          dispatch(Actions.moveUiSchemaElement(uiSchemaElement, uischema, 0));
+          dispatch(
+            Actions.moveUiSchemaElement(uiSchemaElement.uuid, uischema.uuid, 0)
+          );
           break;
       }
     },

--- a/jsonforms-editor/src/core/renderers/DroppableGroupLayout.tsx
+++ b/jsonforms-editor/src/core/renderers/DroppableGroupLayout.tsx
@@ -17,9 +17,8 @@ import {
 } from '@material-ui/core';
 import React from 'react';
 
-import { EditorElement } from '../../editor/components/EditorElement';
 import { EditorLayout } from '../model/uischema';
-import { DroppableLayoutContent } from './DroppableLayout';
+import { DroppableLayout } from './DroppableLayout';
 
 const useStyles = makeStyles((theme) => ({
   groupLabel: {
@@ -41,45 +40,39 @@ const Group: React.FC<LayoutProps> = (props) => {
   const groupLayout = uischema as GroupLayout & EditorLayout;
   const classes = useStyles();
   return (
-    <EditorElement wrappedElement={groupLayout}>
-      <Card>
-        <CardHeader
-          component={() => (
-            <Grid
-              container
-              direction='row'
-              spacing={1}
-              className={classes.groupLabel}
-            >
-              <Grid item>
-                <Typography>Label:</Typography>
-              </Grid>
-              <Grid item>
-                <Typography
-                  className={`${
-                    groupLayout.label ? '' : classes.labelPlaceholder
-                  }`}
-                  variant='h6'
-                >
-                  {groupLayout.label ?? 'no label'}
-                </Typography>
-              </Grid>
+    <Card>
+      <CardHeader
+        component={() => (
+          <Grid
+            container
+            direction='row'
+            spacing={1}
+            className={classes.groupLabel}
+          >
+            <Grid item>
+              <Typography>Label:</Typography>
             </Grid>
-          )}
-        ></CardHeader>
-        <CardContent>
-          <DroppableLayoutContent
-            {...props}
-            layout={groupLayout}
-            direction={'column'}
-          />
-        </CardContent>
-      </Card>
-    </EditorElement>
+            <Grid item>
+              <Typography
+                className={`${
+                  groupLayout.label ? '' : classes.labelPlaceholder
+                }`}
+                variant='h6'
+              >
+                {groupLayout.label ?? 'no label'}
+              </Typography>
+            </Grid>
+          </Grid>
+        )}
+      ></CardHeader>
+      <CardContent>
+        <DroppableLayout {...props} layout={groupLayout} direction={'column'} />
+      </CardContent>
+    </Card>
   );
 };
 
 export const DroppableGroupLayoutRegistration = {
-  tester: rankWith(100, uiTypeIs('Group')),
+  tester: rankWith(45, uiTypeIs('Group')),
   renderer: withJsonFormsLayoutProps(Group),
 };

--- a/jsonforms-editor/src/core/renderers/DroppableLayout.tsx
+++ b/jsonforms-editor/src/core/renderers/DroppableLayout.tsx
@@ -21,7 +21,6 @@ import { Grid, makeStyles } from '@material-ui/core';
 import React from 'react';
 import { useDrop } from 'react-dnd';
 
-import { EditorElement } from '../../editor/components/EditorElement';
 import { useDispatch, useSchema } from '../context';
 import {
   canDropIntoLayout,
@@ -38,6 +37,7 @@ import {
   getUISchemaPath,
 } from '../model/uischema';
 import { isPathError } from '../util/schemasUtil';
+import { DroppableElementRegistration } from './DroppableElement';
 
 const useLayoutStyles = makeStyles((theme) => ({
   dropPointGridItem: {
@@ -65,15 +65,7 @@ interface DroppableLayoutProps {
   cells?: JsonFormsCellRendererRegistryEntry[];
 }
 
-const DroppableLayout: React.FC<DroppableLayoutProps> = (props) => {
-  return (
-    <EditorElement wrappedElement={props.layout}>
-      <DroppableLayoutContent {...props} />
-    </EditorElement>
-  );
-};
-
-export const DroppableLayoutContent: React.FC<DroppableLayoutProps> = ({
+export const DroppableLayout: React.FC<DroppableLayoutProps> = ({
   schema,
   layout,
   path,
@@ -89,28 +81,6 @@ export const DroppableLayoutContent: React.FC<DroppableLayoutProps> = ({
       spacing={direction === 'row' ? 2 : 0}
       wrap='nowrap'
     >
-      {renderLayoutElementsWithDrops(
-        layout,
-        schema,
-        path,
-        classes,
-        renderers,
-        cells
-      )}
-    </Grid>
-  );
-};
-
-const renderLayoutElementsWithDrops = (
-  layout: EditorLayout,
-  schema: JsonSchema,
-  path: string,
-  classes: Record<'dropPointGridItem' | 'jsonformsGridItem', string>,
-  renderers?: JsonFormsRendererRegistryEntry[],
-  cells?: JsonFormsCellRendererRegistryEntry[]
-) => {
-  return (
-    <>
       <Grid
         item
         key={`${path}-${0}-drop`}
@@ -131,7 +101,9 @@ const renderLayoutElementsWithDrops = (
               uischema={child}
               schema={schema}
               path={path}
-              renderers={renderers}
+              renderers={
+                renderers && [...renderers, DroppableElementRegistration]
+              }
               cells={cells}
             />
           </Grid>
@@ -145,7 +117,7 @@ const renderLayoutElementsWithDrops = (
           </Grid>
         </React.Fragment>
       ))}
-    </>
+    </Grid>
   );
 };
 
@@ -247,6 +219,7 @@ const getDataPath = (uischema: EditorUISchemaElement): string => {
 const createRendererInDirection = (direction: 'row' | 'column') => ({
   uischema,
   path,
+  renderers,
   ...props
 }: LayoutProps) => {
   const layout = uischema as EditorLayout;
@@ -256,15 +229,16 @@ const createRendererInDirection = (direction: 'row' | 'column') => ({
       path={path}
       layout={layout}
       direction={direction}
+      renderers={renderers}
     />
   );
 };
 
 export const DroppableHorizontalLayoutRegistration = {
-  tester: rankWith(100, uiTypeIs('HorizontalLayout')),
+  tester: rankWith(45, uiTypeIs('HorizontalLayout')),
   renderer: withJsonFormsLayoutProps(createRendererInDirection('row')),
 };
 export const DroppableVerticalLayoutRegistration = {
-  tester: rankWith(100, uiTypeIs('VerticalLayout')),
+  tester: rankWith(45, uiTypeIs('VerticalLayout')),
   renderer: withJsonFormsLayoutProps(createRendererInDirection('column')),
 };

--- a/jsonforms-editor/src/editor/components/EditorElement.tsx
+++ b/jsonforms-editor/src/editor/components/EditorElement.tsx
@@ -147,7 +147,7 @@ export const EditorElement: React.FC<EditorElementProps> = ({
             onClick={() => {
               hasChildren(wrappedElement)
                 ? setOpenConfirmRemoveDialog(true)
-                : dispatch(Actions.removeUiSchemaElement(wrappedElement));
+                : dispatch(Actions.removeUiSchemaElement(wrappedElement.uuid));
             }}
           >
             <DeleteIcon />
@@ -157,7 +157,7 @@ export const EditorElement: React.FC<EditorElementProps> = ({
             open={openConfirmRemoveDialog}
             text={'Remove element and all its contents from the UI Schema?'}
             onOk={() => {
-              dispatch(Actions.removeUiSchemaElement(wrappedElement));
+              dispatch(Actions.removeUiSchemaElement(wrappedElement.uuid));
               setOpenConfirmRemoveDialog(false);
             }}
             onCancel={() => setOpenConfirmRemoveDialog(false)}

--- a/jsonforms-editor/src/palette-panel/components/SchemaTree.tsx
+++ b/jsonforms-editor/src/palette-panel/components/SchemaTree.tsx
@@ -31,7 +31,7 @@ const SchemaTreeItem: React.FC<SchemaTreeItemProps> = ({ schemaElement }) => {
   const uiSchemaElement: EditorUISchemaElement = createControl(schemaElement);
 
   const [{ isDragging }, drag] = useDrag({
-    item: DndItems.newUISchemaElement(uiSchemaElement, schemaElement),
+    item: DndItems.newUISchemaElement(uiSchemaElement, schemaElement.uuid),
     canDrag: () => {
       return schemaElement.schema.type !== 'object';
     },

--- a/jsonforms-editor/src/properties/components/Properties.tsx
+++ b/jsonforms-editor/src/properties/components/Properties.tsx
@@ -33,7 +33,7 @@ export const Properties = () => {
   const schema = useSchema();
   const dispatch = useDispatch();
 
-  const uiElement: EditorUISchemaElement = useMemo(
+  const uiElement: EditorUISchemaElement | undefined = useMemo(
     () => tryFindByUUID(uiSchema, selection?.uuid),
     [selection, uiSchema]
   );
@@ -52,8 +52,10 @@ export const Properties = () => {
 
   const updateProperties = useCallback(
     ({ data: updatedProperties }) => {
-      if (!isEqual(data, updatedProperties)) {
-        dispatch(Actions.updateUISchemaElement(uiElement, updatedProperties));
+      if (uiElement && !isEqual(data, updatedProperties)) {
+        dispatch(
+          Actions.updateUISchemaElement(uiElement.uuid, updatedProperties)
+        );
       }
     },
     [data, dispatch, uiElement]


### PR DESCRIPTION
- use UUIDs in actions, which are resolved against the current editor state
- match elements by UUID instead of path when cloning
- `DroppableLayout` and `DroppableGroupLayout` should not add their own `EditorElement`

Fixes #70 