### PR TITLE
Improve development setup

### DIFF
--- a/jsonforms-editor/src/core/model/actions.ts
+++ b/jsonforms-editor/src/core/model/actions.ts
@@ -5,8 +5,7 @@
  * https://github.com/eclipsesource/jsonforms-editor/blob/master/LICENSE
  * ---------------------------------------------------------------------
  */
-import { SchemaElement } from './schema';
-import { EditorLayout, EditorUISchemaElement } from './uischema';
+import { EditorUISchemaElement } from './uischema';
 
 export type UiSchemaAction = AddUnscopedElementToLayout | UpdateUiSchemaElement;
 


### PR DESCRIPTION
Adjust CRA scripts to not only transpile but also lint and typecheck
jsonforms-editor sources during developing and building the app.

* Add jsonforms-editor sources to eslint-loader
* Report on typecheck errors found outside of app directory