### PR TITLE
Allow customizing properties and editor view, fix Monaco editors

### DIFF
--- a/jsonforms-editor/src/editor/components/Editor.tsx
+++ b/jsonforms-editor/src/editor/components/Editor.tsx
@@ -5,22 +5,13 @@
  * https://github.com/eclipsesource/jsonforms-editor/blob/master/LICENSE
  * ---------------------------------------------------------------------
  */
-import {
-  materialCells,
-  materialRenderers,
-} from '@jsonforms/material-renderers';
+import { JsonFormsRendererRegistryEntry } from '@jsonforms/core';
+import { materialCells } from '@jsonforms/material-renderers';
 import { JsonForms } from '@jsonforms/react';
 import { createMuiTheme, Grid, ThemeProvider } from '@material-ui/core';
 import React from 'react';
 
 import { useUiSchema } from '../../core/context';
-import { DroppableArrayControlRegistration } from '../../core/renderers/DroppableArrayControl';
-import { DroppableElementRegistration } from '../../core/renderers/DroppableElement';
-import { DroppableGroupLayoutRegistration } from '../../core/renderers/DroppableGroupLayout';
-import {
-  DroppableHorizontalLayoutRegistration,
-  DroppableVerticalLayoutRegistration,
-} from '../../core/renderers/DroppableLayout';
 import { useExportSchema } from '../../core/util/hooks';
 import { EmptyEditor } from './EmptyEditor';
 
@@ -34,16 +25,10 @@ const theme = createMuiTheme({
   },
 });
 
-const renderers = [
-  ...materialRenderers,
-  DroppableHorizontalLayoutRegistration,
-  DroppableVerticalLayoutRegistration,
-  DroppableElementRegistration,
-  DroppableGroupLayoutRegistration,
-  DroppableArrayControlRegistration,
-];
-
-export const Editor: React.FC = () => {
+export interface EditorProps {
+  editorRenderers: JsonFormsRendererRegistryEntry[];
+}
+export const Editor: React.FC<EditorProps> = ({ editorRenderers }) => {
   const schema = useExportSchema();
   const uiSchema = useUiSchema();
   return uiSchema ? (
@@ -53,7 +38,7 @@ export const Editor: React.FC = () => {
           data={{}}
           schema={schema}
           uischema={uiSchema}
-          renderers={renderers}
+          renderers={editorRenderers}
           cells={materialCells}
         />
       </ThemeProvider>

--- a/jsonforms-editor/src/editor/components/EditorElement.tsx
+++ b/jsonforms-editor/src/editor/components/EditorElement.tsx
@@ -23,11 +23,6 @@ import {
 } from '../../core/model/uischema';
 import { tryFindByUUID } from '../../core/util/schemasUtil';
 
-export interface EditorElementProps {
-  wrappedElement: EditorUISchemaElement;
-  onHoverCallback?: (isHover: boolean) => void;
-}
-
 const useEditorElementStyles = makeStyles((theme) => ({
   editorElement: {
     border: '1px solid #d3d3d3',
@@ -62,8 +57,14 @@ const useEditorElementStyles = makeStyles((theme) => ({
   ruleEffect: { fontStyle: 'italic', color: theme.palette.text.secondary },
 }));
 
+export interface EditorElementProps {
+  wrappedElement: EditorUISchemaElement;
+  elementIcon?: React.ReactNode;
+}
+
 export const EditorElement: React.FC<EditorElementProps> = ({
   wrappedElement,
+  elementIcon,
   children,
 }) => {
   const schema = useSchema();
@@ -87,6 +88,14 @@ export const EditorElement: React.FC<EditorElementProps> = ({
   const uiPath = getUISchemaPath(wrappedElement);
   const isSelected = selection?.uuid === wrappedElement.uuid;
   const ruleEffect = wrappedElement.rule?.effect.toLocaleUpperCase();
+
+  const icon =
+    elementIcon ??
+    (elementSchema ? (
+      <SchemaIcon type={elementSchema.type} />
+    ) : (
+      <UISchemaIcon type={wrappedElement.type} />
+    ));
   return (
     <Grid
       item
@@ -110,11 +119,7 @@ export const EditorElement: React.FC<EditorElementProps> = ({
         data-cy={`editorElement-${uiPath}-header`}
       >
         <Grid item container alignItems='center' xs>
-          {elementSchema ? (
-            <SchemaIcon type={elementSchema.type} />
-          ) : (
-            <UISchemaIcon type={wrappedElement.type} />
-          )}
+          {icon}
           {ruleEffect ? (
             <Grid
               item

--- a/jsonforms-editor/src/editor/components/EditorPanel.tsx
+++ b/jsonforms-editor/src/editor/components/EditorPanel.tsx
@@ -5,6 +5,7 @@
  * https://github.com/eclipsesource/jsonforms-editor/blob/master/LICENSE
  * ---------------------------------------------------------------------
  */
+import { JsonFormsRendererRegistryEntry } from '@jsonforms/core';
 import { makeStyles, Tab, Tabs } from '@material-ui/core';
 import React, { useState } from 'react';
 
@@ -27,8 +28,12 @@ export interface EditorTab {
 
 interface EditorPanelProps {
   editorTabs?: EditorTab[];
+  editorRenderers: JsonFormsRendererRegistryEntry[];
 }
-export const EditorPanel: React.FC<EditorPanelProps> = ({ editorTabs }) => {
+export const EditorPanel: React.FC<EditorPanelProps> = ({
+  editorTabs,
+  editorRenderers,
+}) => {
   const [selectedTab, setSelectedTab] = useState(0);
   const handleTabChange = (event: React.ChangeEvent<{}>, newValue: number) => {
     setSelectedTab(newValue);
@@ -45,7 +50,7 @@ export const EditorPanel: React.FC<EditorPanelProps> = ({ editorTabs }) => {
           : null}
       </Tabs>
       <TabContent index={0} currentIndex={selectedTab}>
-        <Editor />
+        <Editor editorRenderers={editorRenderers} />
       </TabContent>
       {editorTabs
         ? editorTabs.map((tab, index) => (

--- a/jsonforms-editor/src/editor/index.ts
+++ b/jsonforms-editor/src/editor/index.ts
@@ -5,13 +5,33 @@
  * https://github.com/eclipsesource/jsonforms-editor/blob/master/LICENSE
  * ---------------------------------------------------------------------
  */
+import { JsonFormsRendererRegistryEntry } from '@jsonforms/core';
+import { materialRenderers } from '@jsonforms/material-renderers';
+
+import { DroppableArrayControlRegistration } from '../core/renderers/DroppableArrayControl';
+import { DroppableElementRegistration } from '../core/renderers/DroppableElement';
+import { DroppableGroupLayoutRegistration } from '../core/renderers/DroppableGroupLayout';
+import {
+  DroppableHorizontalLayoutRegistration,
+  DroppableVerticalLayoutRegistration,
+} from '../core/renderers/DroppableLayout';
 import { EditorTab } from './components/EditorPanel';
 import { ReactMaterialPreview } from './components/preview';
 
 export { EditorPanel } from './components/EditorPanel';
+export { EditorElement } from './components/EditorElement';
 
 export type { EditorTab } from './components/EditorPanel';
 
 export const defaultEditorTabs: EditorTab[] = [
   { name: 'Preview', Component: ReactMaterialPreview },
+];
+
+export const defaultEditorRenderers: JsonFormsRendererRegistryEntry[] = [
+  ...materialRenderers,
+  DroppableHorizontalLayoutRegistration,
+  DroppableVerticalLayoutRegistration,
+  DroppableElementRegistration,
+  DroppableGroupLayoutRegistration,
+  DroppableArrayControlRegistration,
 ];

--- a/jsonforms-editor/src/index.ts
+++ b/jsonforms-editor/src/index.ts
@@ -19,4 +19,5 @@ export * from './core/selection';
 export * from './core/util';
 export * from './editor/components/preview';
 export * from './editor';
+export * from './text-editor';
 export default JsonFormsEditor;

--- a/jsonforms-editor/src/properties/components/Properties.tsx
+++ b/jsonforms-editor/src/properties/components/Properties.tsx
@@ -5,10 +5,8 @@
  * https://github.com/eclipsesource/jsonforms-editor/blob/master/LICENSE
  * ---------------------------------------------------------------------
  */
-import {
-  materialCells,
-  materialRenderers,
-} from '@jsonforms/material-renderers';
+import { JsonFormsRendererRegistryEntry } from '@jsonforms/core';
+import { materialCells } from '@jsonforms/material-renderers';
 import { JsonForms } from '@jsonforms/react';
 import { isEqual, omit } from 'lodash';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
@@ -24,10 +22,13 @@ import { Actions } from '../../core/model';
 import { EditorUISchemaElement } from '../../core/model/uischema';
 import { tryFindByUUID } from '../../core/util/schemasUtil';
 import { PropertySchemas } from '../propertiesService';
-import { RuleEditorRendererRegistration } from '../renderers/RuleEditorRenderer';
 
-const renderers = [...materialRenderers, RuleEditorRendererRegistration];
-export const Properties = () => {
+export interface PropertiesProps {
+  propertyRenderers: JsonFormsRendererRegistryEntry[];
+}
+export const Properties: React.FC<PropertiesProps> = ({
+  propertyRenderers,
+}) => {
   const [selection] = useSelection();
   const uiSchema = useUiSchema();
   const schema = useSchema();
@@ -82,7 +83,7 @@ export const Properties = () => {
       schema={properties.schema}
       uischema={properties.uiSchema}
       onChange={updateProperties}
-      renderers={renderers}
+      renderers={propertyRenderers}
       cells={materialCells}
     />
   ) : (

--- a/jsonforms-editor/src/properties/components/PropertiesPanel.tsx
+++ b/jsonforms-editor/src/properties/components/PropertiesPanel.tsx
@@ -5,18 +5,24 @@
  * https://github.com/eclipsesource/jsonforms-editor/blob/master/LICENSE
  * ---------------------------------------------------------------------
  */
+import { JsonFormsRendererRegistryEntry } from '@jsonforms/core';
 import { Typography } from '@material-ui/core';
 import React from 'react';
 
 import { Properties } from './Properties';
 
-export const PropertiesPanel = () => {
+export interface PropertiesPanelProps {
+  propertyRenderers: JsonFormsRendererRegistryEntry[];
+}
+export const PropertiesPanel: React.FC<PropertiesPanelProps> = ({
+  propertyRenderers,
+}) => {
   return (
     <>
       <Typography variant='h6' color='inherit' noWrap>
         Properties
       </Typography>
-      <Properties />
+      <Properties propertyRenderers={propertyRenderers} />
     </>
   );
 };

--- a/jsonforms-editor/src/properties/index.ts
+++ b/jsonforms-editor/src/properties/index.ts
@@ -5,8 +5,17 @@
  * https://github.com/eclipsesource/jsonforms-editor/blob/master/LICENSE
  * ---------------------------------------------------------------------
  */
+import { materialRenderers } from '@jsonforms/material-renderers';
+
+import { RuleEditorRendererRegistration } from './renderers/RuleEditorRenderer';
+
 export { PropertiesPanel } from './components/PropertiesPanel';
 
 export * from './schemaDecorators';
 export * from './schemaProviders';
 export * from './propertiesService';
+
+export const defaultPropertyRenderers = [
+  ...materialRenderers,
+  RuleEditorRendererRegistration,
+];

--- a/jsonforms-editor/src/text-editor/index.ts
+++ b/jsonforms-editor/src/text-editor/index.ts
@@ -6,4 +6,5 @@
  * ---------------------------------------------------------------------
  */
 export { JsonEditorDialog } from './components/JsonEditorDialog';
-export type { TextType } from './jsonSchemaValidation';
+export type { TextType, EditorApi } from './jsonSchemaValidation';
+export { addSchema } from './jsonSchemaValidation';

--- a/jsonforms-editor/src/text-editor/jsonSchemaValidation.ts
+++ b/jsonforms-editor/src/text-editor/jsonSchemaValidation.ts
@@ -6,6 +6,8 @@
  * ---------------------------------------------------------------------
  */
 import editorApi from 'monaco-editor/esm/vs/editor/editor.api';
+import { Uri } from 'monaco-editor/esm/vs/editor/editor.api';
+import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
 
 import { jsonSchemaDraft7, ruleSchema } from '../core/jsonschema';
 
@@ -13,27 +15,86 @@ export type EditorApi = typeof editorApi;
 export type TextType = 'JSON' | 'JSON Schema' | 'UI Schema';
 
 /**
+ * Register a new schema for the Json language, if it isn't already registered.
+ * Schemas are identified by their uri and fileMatch rule, so that they don't
+ * leak into unrelated Json editors.
+ * @param editor
+ *  The monaco editor
+ * @param schemas
+ *  Schemas to register
+ */
+export const addSchema = (
+  editor: EditorApi,
+  schemas: {
+    uri: string;
+    fileMatch?: string[];
+    schema?: any;
+  }[]
+) => {
+  const registeredSchemas =
+    editor.languages.json.jsonDefaults.diagnosticsOptions.schemas;
+  if (registeredSchemas === undefined) {
+    editor.languages.json.jsonDefaults.setDiagnosticsOptions({
+      validate: true,
+      schemas: [...schemas],
+    });
+  } else {
+    for (const schema of schemas) {
+      const fileMatch = schema.fileMatch;
+
+      const gridSchema = registeredSchemas.find(
+        (registeredSchema) =>
+          registeredSchema.fileMatch === fileMatch &&
+          registeredSchema.uri === schema.uri
+      );
+      if (!gridSchema) {
+        registeredSchemas.push({ ...schema });
+      }
+    }
+  }
+};
+
+/**
  * Configures the Monaco Editor to validate the input against JSON Schema Draft 7.
  */
-export const configureJsonSchemaValidation = (editor: EditorApi) => {
+export const configureJsonSchemaValidation = (
+  editor: EditorApi,
+  modelUri: Uri
+) => {
   /** Note that the Monaco Editor only supports JSON Schema Draft 7 itself,
    * so if we also want to support a later standard we still have to formalize
    * it in JSON Schema Draft 7*/
-  editor.languages.json.jsonDefaults.setDiagnosticsOptions({
-    validate: true,
-    schemas: [{ ...jsonSchemaDraft7, fileMatch: ['*'] }],
-  });
+  addSchema(editor, [
+    { ...jsonSchemaDraft7, fileMatch: [modelUri.toString()] },
+  ]);
 };
 
 /**
  * Configures the Monaco Editor to validate the input against the Rule UI Schema meta-schema.
  */
-export const configureRuleSchemaValidation = (editor: EditorApi) => {
+export const configureRuleSchemaValidation = (
+  editor: EditorApi,
+  modelUri: Uri
+) => {
   /** Note that the Monaco Editor only supports JSON Schema Draft 7 itself,
    * so if we also want to support a later standard we still have to formalize
    * it in JSON Schema Draft 7*/
-  editor.languages.json.jsonDefaults.setDiagnosticsOptions({
-    validate: true,
-    schemas: [{ ...ruleSchema, fileMatch: ['*'] }, { ...jsonSchemaDraft7 }],
-  });
+  addSchema(editor, [
+    { ...jsonSchemaDraft7 },
+    { ...ruleSchema, fileMatch: [modelUri.toString()] },
+  ]);
+};
+
+export const getMonacoModelForUri = (
+  modelUri: Uri,
+  initialValue: string | undefined
+) => {
+  const value = initialValue ?? '';
+  let model = monaco.editor.getModel(modelUri);
+  if (model) {
+    model.setValue(value);
+  } else {
+    model = monaco.editor.createModel(value, 'json', modelUri);
+  }
+  return model;
 };


### PR DESCRIPTION
- allow clients to provide their own renderers for the properties view
- allow clients to provide their own renderers for the editor view
- allow customizing the icon of EditorElements. This is useful e.g. for
client specific schema elements.
- fix Monaco editor integration. We use the Monaco editor in different
places in the UI (JSON Schema view, UI Schema view, Rule editor in the
Properties View). All these instances of the editor are using different
models for the 'json' language, but we were modifying the same model
which is shared between instances. As a result, the schema of the last
opened editor was used in all instances of the Monaco editor. We fixed
this by using the fileMatch filter to match the correct schema for the
editor instance, based on the unique uri of each model.