### PR TITLE
show scope in editor element

### DIFF
--- a/app/cypress/integration/dnd.spec.js
+++ b/app/cypress/integration/dnd.spec.js
@@ -75,9 +75,12 @@ describe('Dnd Move Tests on Example model', () => {
     //check that order is: height, name
     cy.get('[data-cy="editorElement-/elements/0"]').should(
       'have.text',
-      'Height*'
+      '#/properties/personalData/properties/height' + 'Height*'
     );
-    cy.get('[data-cy="editorElement-/elements/1"]').should('have.text', 'Name');
+    cy.get('[data-cy="editorElement-/elements/1"]').should(
+      'have.text',
+      '#/properties/name' + 'Name'
+    );
   });
 
   it('Move element in the same parent, to the right', () => {
@@ -87,10 +90,13 @@ describe('Dnd Move Tests on Example model', () => {
     );
 
     //check that order changed to: name, height
-    cy.get('[data-cy="editorElement-/elements/0"]').should('have.text', 'Name');
-    cy.get('[data-cy="editorElement-/elements/1"]').should(
+    cy.get('[data-cy="editorElement-/elements/0"]').should(
       'have.text',
-      'Height*'
+      '#/properties/name' + 'Name'
+    );
+    cy.get('[data-cy="editorElement-/elements/1"]').should(
+      have.text',
+    '#/properties/personalData/properties/height' + 'Height*'
     );
   });
 
@@ -101,10 +107,13 @@ describe('Dnd Move Tests on Example model', () => {
     );
 
     //check that order changed to: name, height
-    cy.get('[data-cy="editorElement-/elements/0"]').should('have.text', 'Name');
-    cy.get('[data-cy="editorElement-/elements/1"]').should(
+    cy.get('[data-cy="editorElement-/elements/0"]').should(
       'have.text',
-      'Height*'
+      '#/properties/name' + 'Name'
+    );
+    cy.get('[data-cy="editorElement-/elements/1"]').should(
+      have.text',
+    '#/properties/personalData/properties/height' + 'Height*'
     );
   });
 
@@ -115,10 +124,13 @@ describe('Dnd Move Tests on Example model', () => {
     );
 
     //check that order changed to: name, vertical-layout/height
-    cy.get('[data-cy="editorElement-/elements/0"]').should('have.text', 'Name');
+    cy.get('[data-cy="editorElement-/elements/0"]').should(
+      'have.text',
+      '#/properties/name' + 'Name'
+    );
     cy.get('[data-cy="editorElement-/elements/1/elements/0"]').should(
       'have.text',
-      'Height*'
+      '#/properties/personalData/properties/height' + 'Height*'
     );
   });
 
@@ -131,9 +143,12 @@ describe('Dnd Move Tests on Example model', () => {
     //check that order didn't change
     cy.get('[data-cy="editorElement-/elements/0"]').should(
       'have.text',
-      'Height*'
+      '#/properties/personalData/properties/height' + 'Height*'
     );
-    cy.get('[data-cy="editorElement-/elements/1"]').should('have.text', 'Name');
+    cy.get('[data-cy="editorElement-/elements/1"]').should(
+      'have.text',
+      '#/properties/name' + 'Name'
+    );
   });
 
   it('No layout change when droping element in the drop point to its right', () => {
@@ -145,9 +160,12 @@ describe('Dnd Move Tests on Example model', () => {
     //check that order didn't change
     cy.get('[data-cy="editorElement-/elements/0"]').should(
       'have.text',
-      'Height*'
+      '#/properties/personalData/properties/height' + 'Height*'
     );
-    cy.get('[data-cy="editorElement-/elements/1"]').should('have.text', 'Name');
+    cy.get('[data-cy="editorElement-/elements/1"]').should(
+      'have.text',
+      '#/properties/name' + 'Name'
+    );
   });
 
   it('Layout elements are moved with their children', () => {
@@ -163,8 +181,11 @@ describe('Dnd Move Tests on Example model', () => {
     //check height is contained in first element
     cy.get('[data-cy="editorElement-/elements/0/elements/0"]').should(
       'have.text',
-      'Height*'
+      '#/properties/personalData/properties/height' + 'Height*'
     );
-    cy.get('[data-cy="editorElement-/elements/1"]').should('have.text', 'Name');
+    cy.get('[data-cy="editorElement-/elements/1"]').should(
+      'have.text',
+      '#/properties/name' + 'Name'
+    );
   });
 });

--- a/app/cypress/integration/dnd.spec.js
+++ b/app/cypress/integration/dnd.spec.js
@@ -95,8 +95,8 @@ describe('Dnd Move Tests on Example model', () => {
       '#/properties/name' + 'Name'
     );
     cy.get('[data-cy="editorElement-/elements/1"]').should(
-      have.text',
-    '#/properties/personalData/properties/height' + 'Height*'
+      'have.text',
+      '#/properties/personalData/properties/height' + 'Height*'
     );
   });
 
@@ -112,8 +112,8 @@ describe('Dnd Move Tests on Example model', () => {
       '#/properties/name' + 'Name'
     );
     cy.get('[data-cy="editorElement-/elements/1"]').should(
-      have.text',
-    '#/properties/personalData/properties/height' + 'Height*'
+      'have.text',
+      '#/properties/personalData/properties/height' + 'Height*'
     );
   });
 

--- a/app/cypress/integration/editSchemas.spec.js
+++ b/app/cypress/integration/editSchemas.spec.js
@@ -21,6 +21,8 @@ describe('Edit schemas', () => {
 
   const cyReplaceTextInFocus = (jsonObject) => {
     cy.focused()
+      .type('{cmd}a')
+      .type('{del}')
       .type('{ctrl}a')
       .type('{del}')
       .type(JSON.stringify(jsonObject), {

--- a/app/cypress/integration/editor.spec.js
+++ b/app/cypress/integration/editor.spec.js
@@ -65,7 +65,7 @@ describe('Remove controls', () => {
     );
     cy.get('[data-cy="editorElement-/elements/1"]').should(
       'have.text',
-      'Occupation'
+      '#/properties/occupation' + 'Occupation'
     );
   });
 
@@ -94,7 +94,7 @@ describe('Remove controls', () => {
     );
     cy.get('[data-cy="editorElement-/elements/1"]').should(
       'have.text',
-      'Occupation'
+      '#/properties/occupation' + 'Occupation'
     );
   });
 });

--- a/jsonforms-editor/src/core/util/schemasUtil.ts
+++ b/jsonforms-editor/src/core/util/schemasUtil.ts
@@ -98,6 +98,9 @@ const doFindByUUID = (root: any, uuid: string): any | UUIDError => {
   if (root && root.uuid === uuid) {
     return root;
   }
+  if (!root) {
+    return undefined;
+  }
   const entries = root instanceof Map ? root.entries() : Object.entries(root);
   for (const [key, value] of Array.from(entries)) {
     if (value && value.uuid === uuid) {

--- a/jsonforms-editor/src/editor/components/EditorElement.tsx
+++ b/jsonforms-editor/src/editor/components/EditorElement.tsx
@@ -90,11 +90,6 @@ export const EditorElement: React.FC<EditorElementProps> = ({
   const isSelected = selection?.uuid === wrappedElement.uuid;
   const ruleEffect = wrappedElement.rule?.effect.toLocaleUpperCase();
 
-  let scope;
-  if (isEditorControl(wrappedElement)) {
-    scope = wrappedElement.scope;
-  }
-
   const icon =
     elementIcon ??
     (elementSchema ? (
@@ -144,7 +139,7 @@ export const EditorElement: React.FC<EditorElementProps> = ({
               >{`(${ruleEffect})`}</Typography>
             </Grid>
           ) : null}
-          {scope ? (
+          {isEditorControl(wrappedElement) && (
             <Grid
               item
               container
@@ -154,10 +149,10 @@ export const EditorElement: React.FC<EditorElementProps> = ({
               xs
             >
               <Typography variant='caption' className={classes.ruleEffect}>
-                {scope}
+                {wrappedElement.scope}
               </Typography>
             </Grid>
-          ) : null}
+          )}
         </Grid>
         <Grid
           item

--- a/jsonforms-editor/src/editor/components/EditorElement.tsx
+++ b/jsonforms-editor/src/editor/components/EditorElement.tsx
@@ -20,6 +20,7 @@ import {
   EditorUISchemaElement,
   getUISchemaPath,
   hasChildren,
+  isEditorControl,
 } from '../../core/model/uischema';
 import { tryFindByUUID } from '../../core/util/schemasUtil';
 
@@ -89,6 +90,11 @@ export const EditorElement: React.FC<EditorElementProps> = ({
   const isSelected = selection?.uuid === wrappedElement.uuid;
   const ruleEffect = wrappedElement.rule?.effect.toLocaleUpperCase();
 
+  let scope;
+  if (isEditorControl(wrappedElement)) {
+    scope = wrappedElement.scope;
+  }
+
   const icon =
     elementIcon ??
     (elementSchema ? (
@@ -136,6 +142,20 @@ export const EditorElement: React.FC<EditorElementProps> = ({
                 variant='caption'
                 className={classes.ruleEffect}
               >{`(${ruleEffect})`}</Typography>
+            </Grid>
+          ) : null}
+          {scope ? (
+            <Grid
+              item
+              container
+              direction='row'
+              alignItems='center'
+              wrap='nowrap'
+              xs
+            >
+              <Typography variant='caption' className={classes.ruleEffect}>
+                {scope}
+              </Typography>
             </Grid>
           ) : null}
         </Grid>


### PR DESCRIPTION
This PR adds the display of the scope to the EditorElement. This helps with orientation which property is represented by the UI element.
